### PR TITLE
Address PR #18 review: remove meta-tests, add type hint

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,12 +7,14 @@ import os
 import socket
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import httpx
 import pytest
 import uvicorn
 from sqlalchemy import text
+from sqlalchemy.orm import Session
 
 from jm_api.core.config import get_settings
 from jm_api.db.base import Base
@@ -119,7 +121,7 @@ def db_session(integration_server: str):
     session.close()
 
 
-def _do_clean_bots_table(session_factory) -> None:
+def _do_clean_bots_table(session_factory: Callable[[], Session]) -> None:
     """Delete all rows from the bots table.
 
     Shared helper so the autouse fixture and the ``clean_bots_table_fn``

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -154,33 +154,6 @@ class TestCleanBeforePattern:
         assert body["total"] == 0
         assert body["items"] == []
 
-    def test_do_clean_bots_table_requires_session_factory(
-        self, integration_server: str
-    ) -> None:
-        """_do_clean_bots_table must accept a session_factory parameter (explicit dependency)."""
-        import inspect
-        import sys
-
-        # Find the integration conftest module loaded by pytest
-        conftest_mod = None
-        for name, mod in sys.modules.items():
-            if "conftest" in name and hasattr(mod, "_do_clean_bots_table"):
-                conftest_mod = mod
-                break
-        assert conftest_mod is not None, "Could not find conftest with _do_clean_bots_table"
-
-        sig = inspect.signature(conftest_mod._do_clean_bots_table)
-        assert "session_factory" in sig.parameters, (
-            "_do_clean_bots_table should accept a session_factory parameter "
-            "to make the dependency on app startup explicit"
-        )
-
-    def test_clean_bots_table_fn_returns_callable(self, clean_bots_table_fn) -> None:
-        """The clean_bots_table_fn fixture should return a callable."""
-        assert callable(clean_bots_table_fn), (
-            "clean_bots_table_fn fixture should return a callable"
-        )
-
 
 class TestBotDetailEndpoint:
     """Tests for GET /api/v1/bots/{id}."""


### PR DESCRIPTION
## Summary
- Removed `test_do_clean_bots_table_requires_session_factory` — brittle structural introspection test that inspects function signature via `sys.modules` + `inspect.signature`, testing code shape rather than behavior
- Removed `test_clean_bots_table_fn_returns_callable` — redundant `callable()` assertion already proven by behavioral tests that invoke it
- Added `Callable[[], Session]` type annotation to `_do_clean_bots_table(session_factory)` for consistency with the rest of the file

Addresses review feedback on PR #18.

## Test plan
- [x] All unit tests pass: `uv run pytest` (101 passed, 1 skipped)
- [x] All integration tests pass: `uv run pytest tests/integration/ -m integration` (10 passed)
- [x] Ruff lint passes: `uv run ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)