### PR TITLE
Exercise real autouse fixture instead of duplicating SQL

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from jm_api.models.bot import Bot
@@ -108,44 +107,28 @@ class TestBotListEndpoint:
 class TestCleanBeforePattern:
     """Verify the autouse cleanup fixture uses the 'clean before' pattern.
 
-    Instead of relying on two order-dependent tests (which would break under
-    ``pytest-randomly`` or any other test-ordering plugin), a single test
-    inserts a row, then manually invokes the same clean logic the fixture
-    uses and asserts the table is empty afterward.
+    The ``_clean_bots_table`` autouse fixture fires before every test.  Rather
+    than duplicating the fixture's SQL inline (which only proves DELETE works),
+    this test asserts the table is clean at the *start* — proving the real
+    fixture already ran — then inserts a row and deliberately leaves it behind
+    so any subsequent test would fail if the fixture stopped working.
     """
 
     def test_clean_before_pattern_removes_leftover_rows(
         self, http_client: httpx.Client, db_session: Session
     ) -> None:
-        """Insert a bot, run clean logic, and verify the table is empty."""
-        # Arrange: insert a bot so the table is non-empty
+        """Assert the autouse fixture cleaned the table before this test."""
+        # The autouse _clean_bots_table fixture has already fired for THIS
+        # test.  Verify the table is clean at test start.
+        resp = http_client.get("/api/v1/bots")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0, "Fixture should have cleaned before this test"
+
+        # Now insert a row and leave it behind — the NEXT test (any test)
+        # will implicitly verify cleanup.
         bot = Bot(rig_id="leftover-rig")
         db_session.add(bot)
         db_session.commit()
-
-        resp = http_client.get("/api/v1/bots")
-        assert resp.status_code == 200
-        assert resp.json()["total"] >= 1, "Precondition: table should have at least one row"
-
-        # Act: execute the same clean logic the _clean_bots_table fixture uses
-        from jm_api.main import app
-
-        clean_session = app.state.db_session_factory()
-        try:
-            clean_session.execute(text("DELETE FROM bots"))
-            clean_session.commit()
-        finally:
-            clean_session.close()
-
-        # Assert: table is now empty — proves the clean logic works
-        resp = http_client.get("/api/v1/bots")
-        assert resp.status_code == 200
-        body = resp.json()
-        assert body["total"] == 0, (
-            "Expected empty table after clean; "
-            "'clean before' logic did not remove leftover rows"
-        )
-        assert body["items"] == []
 
 
 class TestBotDetailEndpoint:


### PR DESCRIPTION
## Summary
- Rewrote `TestCleanBeforePattern.test_clean_before_pattern_removes_leftover_rows` to exercise the **real** `_clean_bots_table` autouse fixture rather than duplicating its SQL inline
- The test now asserts the table is clean at the **start** (proving the fixture already fired), then inserts a row and leaves it behind
- Removed unused `from sqlalchemy import text` import

Addresses reviewer feedback on PR #16: the previous implementation only proved `DELETE FROM bots` works, not that the autouse fixture is properly wired, scoped, and invoked by pytest.

## Test plan
- [x] All integration tests pass: `uv run pytest tests/integration/ -m integration` (9 passed)
- [x] All unit tests pass: `uv run pytest` (103 passed, 1 skipped)
- [x] Ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)