### PR TITLE
Fix README env var names to use JM_API_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ uv pip install -e ".[dev]"
 JM_API_DATABASE_URL=sqlite:///./dev.db uv run uvicorn jm_api.main:app --reload
 ```
 
-`DATABASE_URL` is required (no default). For local development any SQLite URL works.
-SQLite is rejected when `ENVIRONMENT` is `production` or `staging`.
+`JM_API_DATABASE_URL` is required (no default). For local development any SQLite URL works.
+SQLite is rejected when `JM_API_ENVIRONMENT` is `production` or `staging`.
 
 ## Project Structure
 
@@ -73,17 +73,17 @@ Environment variables are prefixed with `JM_API_` and can be loaded from `.env`.
 Comma-separated values are supported for list settings like `ALLOW_ORIGINS` and
 `ALLOWED_HOSTS`.
 
-| Variable              | Default          | Notes                                     |
-|-----------------------|------------------|-------------------------------------------|
-| `DATABASE_URL`        | *(required)*     | SQLAlchemy connection string              |
-| `ENVIRONMENT`         | `development`    | `production`/`staging` reject SQLite      |
-| `DEBUG`               | `false`          |                                           |
-| `LOG_LEVEL`           | `INFO`           |                                           |
-| `API_V1_PREFIX`       | `/api/v1`        |                                           |
-| `DOCS_ENABLED`        | `true`           | Toggles `/docs`, `/redoc`, `/openapi.json` |
-| `REQUEST_ID_HEADER`   | `X-Request-ID`   |                                           |
-| `ALLOW_ORIGINS`       | *(empty)*        | Comma-separated CORS origins              |
-| `ALLOWED_HOSTS`       | *(empty)*        | Comma-separated trusted hosts             |
+| Variable                   | Default          | Notes                                     |
+|----------------------------|------------------|-------------------------------------------|
+| `JM_API_DATABASE_URL`      | *(required)*     | SQLAlchemy connection string              |
+| `JM_API_ENVIRONMENT`       | `development`    | `production`/`staging` reject SQLite      |
+| `JM_API_DEBUG`             | `false`          |                                           |
+| `JM_API_LOG_LEVEL`         | `INFO`           |                                           |
+| `JM_API_API_V1_PREFIX`     | `/api/v1`        |                                           |
+| `JM_API_DOCS_ENABLED`      | `true`           | Toggles `/docs`, `/redoc`, `/openapi.json` |
+| `JM_API_REQUEST_ID_HEADER` | `X-Request-ID`   |                                           |
+| `JM_API_ALLOW_ORIGINS`     | *(empty)*        | Comma-separated CORS origins              |
+| `JM_API_ALLOWED_HOSTS`     | *(empty)*        | Comma-separated trusted hosts             |
 
 See `.env.example` for defaults and guidance.
 

--- a/tests/test_readme_env_vars.py
+++ b/tests/test_readme_env_vars.py
@@ -1,0 +1,101 @@
+"""Tests for README environment variable naming consistency.
+
+Verifies that the README uses the `JM_API_` prefix consistently
+for all environment variable references, matching the Pydantic Settings
+config which uses `env_prefix="JM_API_"`.
+"""
+
+import re
+from pathlib import Path
+
+README_PATH = Path(__file__).resolve().parent.parent / "README.md"
+
+
+def _read_readme() -> str:
+    return README_PATH.read_text()
+
+
+def _extract_outside_code_blocks(text: str) -> str:
+    """Return README text with fenced code blocks removed."""
+    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+
+
+class TestQuickstartProseUsesPrefix:
+    """Prose below the quickstart code block should reference prefixed env vars."""
+
+    def test_database_url_is_prefixed_in_prose(self):
+        """Line 13 prose should say JM_API_DATABASE_URL, not bare DATABASE_URL."""
+        readme = _read_readme()
+        prose = _extract_outside_code_blocks(readme)
+
+        # Should contain the prefixed version
+        assert "JM_API_DATABASE_URL" in prose, (
+            "Quickstart prose must reference `JM_API_DATABASE_URL`, not bare `DATABASE_URL`"
+        )
+
+    def test_environment_is_prefixed_in_prose(self):
+        """Line 14 prose should say JM_API_ENVIRONMENT, not bare ENVIRONMENT."""
+        readme = _read_readme()
+        prose = _extract_outside_code_blocks(readme)
+
+        # Find lines mentioning ENVIRONMENT in inline code
+        env_refs = re.findall(r"`([^`]*ENVIRONMENT[^`]*)`", prose)
+        for ref in env_refs:
+            assert ref.startswith("JM_API_") or "JM_API_" in ref, (
+                f"Found bare `{ref}` — should be prefixed with JM_API_"
+            )
+
+
+class TestConfigTableUsesPrefix:
+    """The Configuration table should list env vars with JM_API_ prefix."""
+
+    def test_config_table_database_url_prefixed(self):
+        readme = _read_readme()
+        # Look for the config table row containing DATABASE_URL
+        matches = re.findall(r"\|\s*`([\w_]*DATABASE_URL)`", readme)
+        assert matches, "DATABASE_URL should appear in the config table"
+        for m in matches:
+            assert m.startswith("JM_API_"), (
+                f"Config table has `{m}` — should be `JM_API_DATABASE_URL`"
+            )
+
+    def test_config_table_environment_prefixed(self):
+        readme = _read_readme()
+        matches = re.findall(r"\|\s*`([\w_]*ENVIRONMENT)`", readme)
+        assert matches, "ENVIRONMENT should appear in the config table"
+        for m in matches:
+            assert m.startswith("JM_API_"), (
+                f"Config table has `{m}` — should be `JM_API_ENVIRONMENT`"
+            )
+
+    def test_all_config_table_vars_are_prefixed(self):
+        """Every variable in the config table should have the JM_API_ prefix."""
+        readme = _read_readme()
+
+        # Extract variable names from the config table (rows starting with | `...`)
+        # Skip the header row by looking for backtick-wrapped names
+        table_vars = re.findall(r"\|\s*`([\w_]+)`\s*\|", readme)
+
+        # Filter to only known config field names (ignore table header "Variable")
+        for var in table_vars:
+            if var in ("Variable",):
+                continue
+            assert var.startswith("JM_API_"), (
+                f"Config table entry `{var}` is missing the `JM_API_` prefix"
+            )
+
+
+class TestNoBareEnvVarNamesOutsideCodeBlocks:
+    """Ensure no bare (unprefixed) env var names leak into prose."""
+
+    def test_no_bare_database_url_in_prose(self):
+        """Outside code blocks, DATABASE_URL references should be prefixed."""
+        readme = _read_readme()
+        prose = _extract_outside_code_blocks(readme)
+
+        # Find all inline-code references to DATABASE_URL
+        refs = re.findall(r"`([^`]*DATABASE_URL[^`]*)`", prose)
+        for ref in refs:
+            assert "JM_API_" in ref, (
+                f"Found bare `{ref}` in prose — should use `JM_API_DATABASE_URL`"
+            )


### PR DESCRIPTION
## Summary
- Fixes the inconsistency flagged in PR #3 review: env var references in README prose and the Configuration table now consistently use the `JM_API_` prefix (matching `env_prefix="JM_API_"` in Pydantic Settings config)
- Adds `tests/test_readme_env_vars.py` with 6 tests ensuring env var naming consistency is maintained

## Changes
- **README.md**: Prefixed `DATABASE_URL` → `JM_API_DATABASE_URL` and `ENVIRONMENT` → `JM_API_ENVIRONMENT` in quickstart prose (lines 13–14). All 9 entries in the Configuration table now use the `JM_API_` prefix.
- **tests/test_readme_env_vars.py**: 6 new tests covering quickstart prose, config table entries, and no-bare-names-outside-code-blocks.

## Test plan
- [x] All 6 new README env var tests pass
- [x] Full test suite passes (109 passed, 1 skipped, 8 deselected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)