### PR TITLE
Add Delete button with confirmation to Edit Record page

### DIFF
--- a/src/jm_api/api/generic/__init__.py
+++ b/src/jm_api/api/generic/__init__.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 from jm_api.api.generic.router import (
     create_create_router,
+    create_delete_router,
     create_read_router,
     create_update_router,
 )
 
-__all__ = ["create_create_router", "create_read_router", "create_update_router"]
+__all__ = [
+    "create_create_router",
+    "create_delete_router",
+    "create_read_router",
+    "create_update_router",
+]

--- a/src/jm_api/api/routes/bots.py
+++ b/src/jm_api/api/routes/bots.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
-from jm_api.api.generic import create_create_router, create_read_router, create_update_router
+from jm_api.api.generic import (
+    create_create_router,
+    create_delete_router,
+    create_read_router,
+    create_update_router,
+)
 from jm_api.api.generic.filters import FilterField, FilterType
 from jm_api.models.bot import Bot
 from jm_api.schemas.bot import BotCreate, BotResponse, BotUpdate
@@ -45,7 +50,15 @@ _update_router = create_update_router(
     resource_name="Bot",
 )
 
+_delete_router = create_delete_router(
+    prefix="/bots",
+    tags=["bots"],
+    model=Bot,
+    resource_name="Bot",
+)
+
 router = APIRouter()
 router.include_router(_read_router)
 router.include_router(_create_router)
 router.include_router(_update_router)
+router.include_router(_delete_router)

--- a/src/jm_api/static/app.js
+++ b/src/jm_api/static/app.js
@@ -299,6 +299,28 @@ function renderEditForm(table, id, fields, record) {
   btn.textContent = "Save";
   form.appendChild(btn);
 
+  var deleteBtn = document.createElement("button");
+  deleteBtn.setAttribute("type", "button");
+  deleteBtn.setAttribute("class", "btn btn-danger");
+  deleteBtn.textContent = "Delete";
+  deleteBtn.addEventListener("click", function () {
+    if (confirm("Are you sure you want to delete this record?")) {
+      fetch("/api/v1/" + table + "/" + id, { method: "DELETE" })
+        .then(function (response) {
+          if (!response.ok) {
+            return response.json().then(function (err) {
+              throw new Error(formatError(err));
+            });
+          }
+          location.href = "table.html?table=" + encodeURIComponent(table);
+        })
+        .catch(function (err) {
+          showError(err.message);
+        });
+    }
+  });
+  form.appendChild(deleteBtn);
+
   form.addEventListener("submit", function (e) {
     e.preventDefault();
     submitEditForm(table, id, fields);

--- a/src/jm_api/static/style.css
+++ b/src/jm_api/static/style.css
@@ -118,6 +118,18 @@ tbody tr:hover {
   border-color: #0a58ca;
 }
 
+.btn-danger {
+  color: #fff;
+  background: #dc3545;
+  border-color: #dc3545;
+  margin-left: 0.5rem;
+}
+
+.btn-danger:hover {
+  background: #bb2d3b;
+  border-color: #b02a37;
+}
+
 /* Form layout */
 .form-group {
   margin-bottom: 1rem;

--- a/tests/test_delete_bot.py
+++ b/tests/test_delete_bot.py
@@ -1,0 +1,282 @@
+"""Tests for Bot delete (DELETE) API endpoint.
+
+Covers spec acceptance criteria:
+- DELETE /api/v1/bots/{id} returns 204 and removes the record
+- DELETE /api/v1/bots/{invalid_id} returns 404
+- Error response displayed if delete fails
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+
+class TestDeleteBotSuccess:
+    """Test DELETE /api/v1/bots/{id} removes a record."""
+
+    def test_delete_bot_returns_204(self, client: TestClient, bot_factory) -> None:
+        """Successful delete returns 204 No Content."""
+        bot = bot_factory(rig_id="rig-delete")
+        response = client.delete(f"/api/v1/bots/{bot.id}")
+        assert response.status_code == 204
+
+    def test_delete_bot_returns_empty_body(self, client: TestClient, bot_factory) -> None:
+        """Successful delete response has no body."""
+        bot = bot_factory(rig_id="rig-empty-body")
+        response = client.delete(f"/api/v1/bots/{bot.id}")
+        assert response.content == b""
+
+    def test_deleted_bot_not_found_on_get(self, client: TestClient, bot_factory) -> None:
+        """Deleted bot returns 404 when fetched via GET."""
+        bot = bot_factory(rig_id="rig-gone")
+        client.delete(f"/api/v1/bots/{bot.id}")
+        get_resp = client.get(f"/api/v1/bots/{bot.id}")
+        assert get_resp.status_code == 404
+
+    def test_deleted_bot_excluded_from_list(self, client: TestClient, bot_factory) -> None:
+        """Deleted bot does not appear in list endpoint results."""
+        bot1 = bot_factory(rig_id="rig-keep")
+        bot2 = bot_factory(rig_id="rig-remove")
+        client.delete(f"/api/v1/bots/{bot2.id}")
+
+        list_resp = client.get("/api/v1/bots")
+        items = list_resp.json()["items"]
+        ids = [item["id"] for item in items]
+        assert bot1.id in ids
+        assert bot2.id not in ids
+
+    def test_delete_one_bot_does_not_affect_others(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Deleting one bot leaves other bots intact."""
+        bot_keep = bot_factory(rig_id="rig-survivor")
+        bot_delete = bot_factory(rig_id="rig-doomed")
+        client.delete(f"/api/v1/bots/{bot_delete.id}")
+
+        get_resp = client.get(f"/api/v1/bots/{bot_keep.id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["rig_id"] == "rig-survivor"
+
+    def test_list_total_decremented_after_delete(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Total count in list response decreases by 1 after deletion."""
+        bot_factory(rig_id="rig-count-1")
+        bot2 = bot_factory(rig_id="rig-count-2")
+
+        before = client.get("/api/v1/bots").json()["total"]
+        client.delete(f"/api/v1/bots/{bot2.id}")
+        after = client.get("/api/v1/bots").json()["total"]
+
+        assert after == before - 1
+
+    def test_delete_bot_with_all_fields_populated(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Bot with all fields set (including optional) can be deleted."""
+        bot = bot_factory(
+            rig_id="rig-full",
+            kill_switch=True,
+            last_run_log="Complete run log entry",
+            last_run_at=datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        response = client.delete(f"/api/v1/bots/{bot.id}")
+        assert response.status_code == 204
+
+        get_resp = client.get(f"/api/v1/bots/{bot.id}")
+        assert get_resp.status_code == 404
+
+
+class TestDeleteBotNotFound:
+    """Test DELETE /api/v1/bots/{id} with nonexistent ID."""
+
+    def test_nonexistent_bot_returns_404(self, client: TestClient) -> None:
+        """DELETE of nonexistent bot ID returns 404."""
+        fake_id = "x" * 32
+        response = client.delete(f"/api/v1/bots/{fake_id}")
+        assert response.status_code == 404
+
+    def test_404_response_contains_message(self, client: TestClient) -> None:
+        """404 response includes human-readable message with model name."""
+        fake_id = "a" * 32
+        response = client.delete(f"/api/v1/bots/{fake_id}")
+        data = response.json()
+        assert data["detail"]["message"] == "Bot not found"
+
+    def test_404_response_contains_id(self, client: TestClient) -> None:
+        """404 response includes the requested ID."""
+        fake_id = "b" * 32
+        response = client.delete(f"/api/v1/bots/{fake_id}")
+        data = response.json()
+        assert data["detail"]["id"] == fake_id
+
+    def test_404_detail_has_correct_structure(self, client: TestClient) -> None:
+        """404 detail contains exactly message and id keys."""
+        fake_id = "c" * 32
+        response = client.delete(f"/api/v1/bots/{fake_id}")
+        detail = response.json()["detail"]
+        assert isinstance(detail, dict)
+        assert set(detail.keys()) == {"message", "id"}
+
+    def test_404_response_is_json(self, client: TestClient) -> None:
+        """404 error response has application/json content type."""
+        fake_id = "d" * 32
+        response = client.delete(f"/api/v1/bots/{fake_id}")
+        assert "application/json" in response.headers.get("content-type", "")
+
+
+class TestDeleteBotIdempotency:
+    """Test that deleting the same record twice behaves correctly."""
+
+    def test_second_delete_returns_404(self, client: TestClient, bot_factory) -> None:
+        """Deleting an already-deleted record returns 404."""
+        bot = bot_factory(rig_id="rig-twice")
+        first = client.delete(f"/api/v1/bots/{bot.id}")
+        assert first.status_code == 204
+
+        second = client.delete(f"/api/v1/bots/{bot.id}")
+        assert second.status_code == 404
+
+    def test_second_delete_404_has_correct_message(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Second delete of same record includes proper 404 error body."""
+        bot = bot_factory(rig_id="rig-twice-msg")
+        client.delete(f"/api/v1/bots/{bot.id}")
+
+        second = client.delete(f"/api/v1/bots/{bot.id}")
+        data = second.json()
+        assert data["detail"]["message"] == "Bot not found"
+        assert data["detail"]["id"] == bot.id
+
+
+class TestDeleteBotIdValidation:
+    """Test path parameter validation on DELETE endpoint."""
+
+    def test_short_id_returns_422(self, client: TestClient) -> None:
+        """ID shorter than 32 characters is rejected."""
+        response = client.delete("/api/v1/bots/abc")
+        assert response.status_code == 422
+
+    def test_long_id_returns_422(self, client: TestClient) -> None:
+        """ID longer than 32 characters is rejected."""
+        long_id = "a" * 33
+        response = client.delete(f"/api/v1/bots/{long_id}")
+        assert response.status_code == 422
+
+    def test_special_chars_in_id_returns_422(self, client: TestClient) -> None:
+        """ID with special characters is rejected."""
+        bad_id = "abc!@#$%^&*()_+{}|:<>?-=[]\\;',./"
+        response = client.delete(f"/api/v1/bots/{bad_id}")
+        assert response.status_code == 422
+
+    def test_id_with_spaces_returns_422(self, client: TestClient) -> None:
+        """ID containing spaces is rejected."""
+        response = client.delete("/api/v1/bots/abcdefghijklmnop qrstuvwxyz12345")
+        assert response.status_code == 422
+
+    def test_valid_format_id_accepted(self, client: TestClient) -> None:
+        """32-char alphanumeric ID passes validation (returns 404, not 422)."""
+        valid_id = "abcdefghijklmnopqrstuvwxyz123456"
+        response = client.delete(f"/api/v1/bots/{valid_id}")
+        # 404 because record doesn't exist, but NOT 422 — validation passed
+        assert response.status_code == 404
+
+    def test_uppercase_id_passes_validation(self, client: TestClient) -> None:
+        """32-char uppercase alphanumeric ID passes regex validation."""
+        upper_id = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"
+        response = client.delete(f"/api/v1/bots/{upper_id}")
+        assert response.status_code == 404
+
+    def test_single_char_id_returns_422(self, client: TestClient) -> None:
+        """Single-character ID is rejected."""
+        response = client.delete("/api/v1/bots/a")
+        assert response.status_code == 422
+
+    def test_sql_injection_in_id_returns_422(self, client: TestClient) -> None:
+        """SQL injection attempt in ID is rejected by regex."""
+        response = client.delete("/api/v1/bots/1'; DROP TABLE bots;--aaaaaaa")
+        assert response.status_code == 422
+
+
+class TestDeleteBotIntegration:
+    """Integration tests: delete interacts correctly with other operations."""
+
+    def test_delete_after_update(self, client: TestClient, bot_factory) -> None:
+        """Bot can be deleted after being updated."""
+        bot = bot_factory(rig_id="rig-update-then-delete")
+        # Update the bot
+        client.put(
+            f"/api/v1/bots/{bot.id}",
+            json={"rig_id": "rig-updated"},
+        )
+        # Now delete
+        response = client.delete(f"/api/v1/bots/{bot.id}")
+        assert response.status_code == 204
+
+        get_resp = client.get(f"/api/v1/bots/{bot.id}")
+        assert get_resp.status_code == 404
+
+    def test_update_after_delete_returns_404(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Updating a deleted bot returns 404."""
+        bot = bot_factory(rig_id="rig-delete-then-update")
+        client.delete(f"/api/v1/bots/{bot.id}")
+
+        response = client.put(
+            f"/api/v1/bots/{bot.id}",
+            json={"rig_id": "rig-ghost"},
+        )
+        assert response.status_code == 404
+
+    def test_delete_all_bots_one_by_one(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Deleting all bots empties the collection."""
+        bots = [bot_factory(rig_id=f"rig-{i}") for i in range(3)]
+
+        for bot in bots:
+            resp = client.delete(f"/api/v1/bots/{bot.id}")
+            assert resp.status_code == 204
+
+        list_resp = client.get("/api/v1/bots")
+        assert list_resp.json()["total"] == 0
+        assert list_resp.json()["items"] == []
+
+    def test_create_after_delete(self, client: TestClient, bot_factory) -> None:
+        """New bots can be created after deleting existing ones."""
+        bot = bot_factory(rig_id="rig-old")
+        client.delete(f"/api/v1/bots/{bot.id}")
+
+        new_resp = client.post("/api/v1/bots", json={"rig_id": "rig-new"})
+        assert new_resp.status_code == 201
+        assert new_resp.json()["rig_id"] == "rig-new"
+
+    def test_filter_excludes_deleted_bot(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Deleted bots are excluded from filtered list results."""
+        bot1 = bot_factory(rig_id="rig-same")
+        bot2 = bot_factory(rig_id="rig-same")
+        client.delete(f"/api/v1/bots/{bot1.id}")
+
+        list_resp = client.get("/api/v1/bots", params={"rig_id": "rig-same"})
+        data = list_resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["id"] == bot2.id
+
+    def test_pagination_correct_after_delete(
+        self, client: TestClient, bot_factory
+    ) -> None:
+        """Pagination metadata updates correctly after deletion."""
+        bots = [bot_factory(rig_id=f"rig-page-{i}") for i in range(3)]
+        client.delete(f"/api/v1/bots/{bots[0].id}")
+
+        list_resp = client.get("/api/v1/bots", params={"per_page": 2})
+        data = list_resp.json()
+        assert data["total"] == 2
+        assert data["pages"] == 1
+        assert len(data["items"]) == 2

--- a/tests/test_generic_delete_router.py
+++ b/tests/test_generic_delete_router.py
@@ -1,0 +1,458 @@
+"""Tests for generic delete router factory using minimal Gadget model.
+
+Mirrors the test pattern from test_generic_update_router.py: uses a
+standalone Widget model so the generic delete factory is tested in
+isolation from any specific resource (e.g. Bot).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+import sqlalchemy as sa
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import Boolean, String, Text
+from sqlalchemy.orm import Mapped, Session, mapped_column, sessionmaker
+
+from jm_api.api.generic.filters import FilterField, FilterType
+from jm_api.api.generic.router import (
+    create_create_router,
+    create_delete_router,
+    create_read_router,
+)
+from jm_api.db.base import Base, TimestampedIdBase
+from jm_api.db.session import get_db
+
+
+# --- Test model and schemas ---
+
+
+class Gadget(TimestampedIdBase):
+    """Minimal model for testing generic delete router."""
+
+    __tablename__ = "gadgets_delete"
+
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    active: Mapped[bool] = mapped_column(Boolean, default=True)
+    description: Mapped[str | None] = mapped_column(Text, default=None)
+
+
+class GadgetResponse(BaseModel):
+    id: str
+    name: str
+    active: bool
+    description: str | None
+    create_at: datetime
+    last_update_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GadgetCreate(BaseModel):
+    name: str
+    active: bool = True
+    description: str | None = None
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def gadget_engine():
+    engine = sa.create_engine(
+        "sqlite+pysqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=sa.pool.StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+def gadget_session(gadget_engine) -> Session:
+    session = Session(gadget_engine)
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def gadget_app(gadget_engine, gadget_session: Session) -> FastAPI:
+    app = FastAPI()
+    app.state.db_engine = gadget_engine
+    app.state.db_session_factory = sessionmaker(bind=gadget_engine)
+
+    def override_get_db():
+        yield gadget_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    read_router = create_read_router(
+        prefix="/gadgets",
+        tags=["gadgets"],
+        model=Gadget,
+        response_schema=GadgetResponse,
+        filter_config=[FilterField("name", FilterType.EXACT)],
+        resource_name="Gadget",
+    )
+    create_router = create_create_router(
+        prefix="/gadgets",
+        tags=["gadgets"],
+        model=Gadget,
+        response_schema=GadgetResponse,
+        create_schema=GadgetCreate,
+        resource_name="Gadget",
+    )
+    delete_router = create_delete_router(
+        prefix="/gadgets",
+        tags=["gadgets"],
+        model=Gadget,
+        resource_name="Gadget",
+    )
+    app.include_router(read_router)
+    app.include_router(create_router)
+    app.include_router(delete_router)
+    return app
+
+
+@pytest.fixture
+def gadget_client(gadget_app: FastAPI) -> TestClient:
+    return TestClient(gadget_app)
+
+
+def _create_gadget(client: TestClient, **kwargs) -> dict:
+    """Helper to create a gadget and return its JSON."""
+    payload = {"name": "test-gadget", **kwargs}
+    resp = client.post("/gadgets", json=payload)
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# --- Delete Endpoint Tests ---
+
+
+class TestGenericDeleteSuccess:
+    """Test that DELETE /{prefix}/{id} removes a record."""
+
+    def test_delete_returns_204(self, gadget_client: TestClient) -> None:
+        """Successful DELETE returns 204 No Content."""
+        gadget = _create_gadget(gadget_client)
+        response = gadget_client.delete(f"/gadgets/{gadget['id']}")
+        assert response.status_code == 204
+
+    def test_delete_returns_empty_body(self, gadget_client: TestClient) -> None:
+        """Successful DELETE response has no body."""
+        gadget = _create_gadget(gadget_client)
+        response = gadget_client.delete(f"/gadgets/{gadget['id']}")
+        assert response.content == b""
+
+    def test_deleted_record_not_found_on_get(self, gadget_client: TestClient) -> None:
+        """GET after DELETE returns 404."""
+        gadget = _create_gadget(gadget_client)
+        gadget_client.delete(f"/gadgets/{gadget['id']}")
+        get_resp = gadget_client.get(f"/gadgets/{gadget['id']}")
+        assert get_resp.status_code == 404
+
+    def test_deleted_record_excluded_from_list(self, gadget_client: TestClient) -> None:
+        """Deleted record does not appear in list endpoint."""
+        g1 = _create_gadget(gadget_client, name="keep-me")
+        g2 = _create_gadget(gadget_client, name="delete-me")
+        gadget_client.delete(f"/gadgets/{g2['id']}")
+
+        list_resp = gadget_client.get("/gadgets")
+        ids = [item["id"] for item in list_resp.json()["items"]]
+        assert g1["id"] in ids
+        assert g2["id"] not in ids
+
+    def test_delete_does_not_affect_other_records(
+        self, gadget_client: TestClient
+    ) -> None:
+        """Deleting one record leaves others intact."""
+        g_keep = _create_gadget(gadget_client, name="survivor")
+        g_delete = _create_gadget(gadget_client, name="doomed")
+        gadget_client.delete(f"/gadgets/{g_delete['id']}")
+
+        get_resp = gadget_client.get(f"/gadgets/{g_keep['id']}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["name"] == "survivor"
+
+    def test_list_count_decremented_after_delete(
+        self, gadget_client: TestClient
+    ) -> None:
+        """Total count in list response decreases after deletion."""
+        _create_gadget(gadget_client, name="one")
+        g2 = _create_gadget(gadget_client, name="two")
+
+        before = gadget_client.get("/gadgets").json()["total"]
+        gadget_client.delete(f"/gadgets/{g2['id']}")
+        after = gadget_client.get("/gadgets").json()["total"]
+
+        assert after == before - 1
+
+
+class TestGenericDeleteNotFound:
+    """Test DELETE /{prefix}/{id} with nonexistent ID."""
+
+    def test_nonexistent_returns_404(self, gadget_client: TestClient) -> None:
+        """DELETE of nonexistent ID returns 404."""
+        fake_id = "z" * 32
+        response = gadget_client.delete(f"/gadgets/{fake_id}")
+        assert response.status_code == 404
+
+    def test_404_includes_resource_name_in_message(
+        self, gadget_client: TestClient
+    ) -> None:
+        """404 message uses the configured resource_name."""
+        fake_id = "z" * 32
+        response = gadget_client.delete(f"/gadgets/{fake_id}")
+        data = response.json()
+        assert data["detail"]["message"] == "Gadget not found"
+
+    def test_404_includes_requested_id(self, gadget_client: TestClient) -> None:
+        """404 body includes the ID that was requested."""
+        fake_id = "y" * 32
+        response = gadget_client.delete(f"/gadgets/{fake_id}")
+        data = response.json()
+        assert data["detail"]["id"] == fake_id
+
+
+class TestGenericDeleteIdempotency:
+    """Test repeated deletes on the same record."""
+
+    def test_second_delete_returns_404(self, gadget_client: TestClient) -> None:
+        """Deleting an already-deleted record returns 404."""
+        gadget = _create_gadget(gadget_client)
+        first = gadget_client.delete(f"/gadgets/{gadget['id']}")
+        assert first.status_code == 204
+
+        second = gadget_client.delete(f"/gadgets/{gadget['id']}")
+        assert second.status_code == 404
+
+
+class TestGenericDeleteIdValidation:
+    """Test path parameter validation on DELETE endpoint."""
+
+    def test_short_id_rejected(self, gadget_client: TestClient) -> None:
+        """ID shorter than 32 characters is rejected with 422."""
+        response = gadget_client.delete("/gadgets/short")
+        assert response.status_code == 422
+
+    def test_long_id_rejected(self, gadget_client: TestClient) -> None:
+        """ID longer than 32 characters is rejected with 422."""
+        long_id = "a" * 33
+        response = gadget_client.delete(f"/gadgets/{long_id}")
+        assert response.status_code == 422
+
+    def test_special_characters_rejected(self, gadget_client: TestClient) -> None:
+        """ID with special characters is rejected with 422."""
+        bad_id = "abc-def_ghi.jkl!mnopqrstuvwxyz12"
+        response = gadget_client.delete(f"/gadgets/{bad_id}")
+        assert response.status_code == 422
+
+    def test_uppercase_letters_accepted(self, gadget_client: TestClient) -> None:
+        """ID with uppercase letters passes validation (404, not 422)."""
+        upper_id = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"
+        response = gadget_client.delete(f"/gadgets/{upper_id}")
+        assert response.status_code == 404
+
+    def test_mixed_case_alphanumeric_accepted(self, gadget_client: TestClient) -> None:
+        """Mixed-case alphanumeric 32-char ID passes validation."""
+        mixed_id = "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoO01"
+        response = gadget_client.delete(f"/gadgets/{mixed_id}")
+        assert response.status_code == 404
+
+
+class TestGenericDeleteRouteNaming:
+    """Test that the factory produces correctly-named routes."""
+
+    def test_route_function_name_includes_resource(self) -> None:
+        """Delete route function is named after the resource."""
+        router = create_delete_router(
+            prefix="/gadgets",
+            tags=["gadgets"],
+            model=Gadget,
+            resource_name="Gadget",
+        )
+        route_names = [route.name for route in router.routes]
+        assert any("gadget" in name for name in route_names), (
+            f"Expected resource name in route names, got: {route_names}"
+        )
+
+    def test_route_name_is_delete_prefixed(self) -> None:
+        """Delete route name starts with 'delete_'."""
+        router = create_delete_router(
+            prefix="/gadgets",
+            tags=["gadgets"],
+            model=Gadget,
+            resource_name="Gadget",
+        )
+        route_names = [route.name for route in router.routes]
+        assert "delete_gadget" in route_names, (
+            f"Expected 'delete_gadget' in route names, got: {route_names}"
+        )
+
+
+class TestGenericDeleteCustomIdPattern:
+    """Test delete router with a custom ID regex pattern."""
+
+    @pytest.fixture
+    def custom_id_app(self, gadget_engine, gadget_session: Session) -> FastAPI:
+        """App with a delete router that only accepts numeric IDs."""
+        app = FastAPI()
+        app.state.db_engine = gadget_engine
+        app.state.db_session_factory = sessionmaker(bind=gadget_engine)
+
+        def override_get_db():
+            yield gadget_session
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        delete_router = create_delete_router(
+            prefix="/gadgets",
+            tags=["gadgets"],
+            model=Gadget,
+            resource_name="Gadget",
+            id_pattern=r"^[0-9]{8}$",
+        )
+        app.include_router(delete_router)
+        return app
+
+    @pytest.fixture
+    def custom_id_client(self, custom_id_app: FastAPI) -> TestClient:
+        return TestClient(custom_id_app)
+
+    def test_custom_pattern_rejects_default_format(
+        self, custom_id_client: TestClient
+    ) -> None:
+        """Default 32-char alphanumeric ID is rejected by numeric-only pattern."""
+        default_id = "a" * 32
+        response = custom_id_client.delete(f"/gadgets/{default_id}")
+        assert response.status_code == 422
+
+    def test_custom_pattern_accepts_matching_format(
+        self, custom_id_client: TestClient
+    ) -> None:
+        """8-digit numeric ID passes custom validation (404, not 422)."""
+        numeric_id = "12345678"
+        response = custom_id_client.delete(f"/gadgets/{numeric_id}")
+        assert response.status_code == 404
+
+
+class TestGenericDeleteIdValidationEdgeCases:
+    """Extended ID validation edge cases for DELETE endpoint."""
+
+    def test_empty_string_id_returns_404_or_405(self, gadget_client: TestClient) -> None:
+        """Empty string ID hits the collection endpoint, not the item endpoint."""
+        response = gadget_client.delete("/gadgets/")
+        # Empty path segment — either 404 (no route) or 405 (method not allowed)
+        assert response.status_code in (404, 405)
+
+    def test_numeric_only_32char_id_accepted(self, gadget_client: TestClient) -> None:
+        """32-character all-numeric ID passes validation."""
+        numeric_id = "1" * 32
+        response = gadget_client.delete(f"/gadgets/{numeric_id}")
+        assert response.status_code == 404  # valid format, record doesn't exist
+
+    def test_unicode_characters_rejected(self, gadget_client: TestClient) -> None:
+        """ID with unicode characters is rejected with 422."""
+        unicode_id = "abcdefghijklmnopqrstuvwx\u00e9\u00e8\u00ea\u00eb\u00ec\u00ed\u00ee\u00ef"
+        response = gadget_client.delete(f"/gadgets/{unicode_id}")
+        assert response.status_code == 422
+
+    def test_whitespace_only_id_rejected(self, gadget_client: TestClient) -> None:
+        """ID consisting only of spaces is rejected."""
+        response = gadget_client.delete("/gadgets/" + " " * 32)
+        assert response.status_code == 422
+
+    def test_sql_injection_in_id_rejected(self, gadget_client: TestClient) -> None:
+        """SQL injection attempt in ID is rejected by regex validation."""
+        response = gadget_client.delete("/gadgets/1'; DROP TABLE gadgets;--aaaa")
+        assert response.status_code == 422
+
+
+class TestGenericDeleteMultipleRecords:
+    """Test delete behavior with multiple records present."""
+
+    def test_delete_first_of_many(self, gadget_client: TestClient) -> None:
+        """Deleting the first created record leaves others intact."""
+        g1 = _create_gadget(gadget_client, name="first")
+        g2 = _create_gadget(gadget_client, name="second")
+        g3 = _create_gadget(gadget_client, name="third")
+
+        gadget_client.delete(f"/gadgets/{g1['id']}")
+
+        # Remaining records are accessible
+        assert gadget_client.get(f"/gadgets/{g2['id']}").status_code == 200
+        assert gadget_client.get(f"/gadgets/{g3['id']}").status_code == 200
+        assert gadget_client.get(f"/gadgets/{g1['id']}").status_code == 404
+
+    def test_delete_all_records_one_by_one(self, gadget_client: TestClient) -> None:
+        """Deleting all records one by one empties the collection."""
+        g1 = _create_gadget(gadget_client, name="one")
+        g2 = _create_gadget(gadget_client, name="two")
+        g3 = _create_gadget(gadget_client, name="three")
+
+        for gid in [g1["id"], g2["id"], g3["id"]]:
+            resp = gadget_client.delete(f"/gadgets/{gid}")
+            assert resp.status_code == 204
+
+        list_resp = gadget_client.get("/gadgets")
+        assert list_resp.json()["total"] == 0
+        assert list_resp.json()["items"] == []
+
+    def test_create_after_delete_succeeds(self, gadget_client: TestClient) -> None:
+        """New records can be created after deleting existing ones."""
+        g1 = _create_gadget(gadget_client, name="original")
+        gadget_client.delete(f"/gadgets/{g1['id']}")
+
+        g2 = _create_gadget(gadget_client, name="replacement")
+        assert g2["id"] != g1["id"]
+
+        get_resp = gadget_client.get(f"/gadgets/{g2['id']}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["name"] == "replacement"
+
+    def test_delete_does_not_reuse_id(self, gadget_client: TestClient) -> None:
+        """Deleted record's ID is not reused for new records."""
+        g1 = _create_gadget(gadget_client, name="original")
+        deleted_id = g1["id"]
+        gadget_client.delete(f"/gadgets/{deleted_id}")
+
+        # Create several new records and verify none reuse the deleted ID
+        new_ids = []
+        for i in range(5):
+            g = _create_gadget(gadget_client, name=f"new-{i}")
+            new_ids.append(g["id"])
+
+        assert deleted_id not in new_ids
+
+
+class TestGenericDeleteResponseHeaders:
+    """Test HTTP response details for DELETE endpoint."""
+
+    def test_successful_delete_content_length_zero(
+        self, gadget_client: TestClient
+    ) -> None:
+        """Successful 204 response has zero content length."""
+        gadget = _create_gadget(gadget_client)
+        response = gadget_client.delete(f"/gadgets/{gadget['id']}")
+        assert response.status_code == 204
+        assert len(response.content) == 0
+
+    def test_404_response_is_json(self, gadget_client: TestClient) -> None:
+        """404 error response has JSON content type."""
+        fake_id = "z" * 32
+        response = gadget_client.delete(f"/gadgets/{fake_id}")
+        assert response.status_code == 404
+        assert "application/json" in response.headers.get("content-type", "")
+
+    def test_404_detail_structure_is_dict(self, gadget_client: TestClient) -> None:
+        """404 response detail is a dict with message and id keys."""
+        fake_id = "z" * 32
+        response = gadget_client.delete(f"/gadgets/{fake_id}")
+        detail = response.json()["detail"]
+        assert isinstance(detail, dict)
+        assert set(detail.keys()) == {"message", "id"}


### PR DESCRIPTION
## Summary

- Add generic `create_delete_router` factory with `DELETE /{id}` endpoint (204 on success, 404 with structured error for missing records, regex ID validation)
- Wire up delete endpoint for bots via `_delete_router` in `bots.py`
- Add red "Delete" button with `confirm()` dialog to the edit page; redirects to table list on success, shows error on failure
- Add `btn-danger` CSS styles for the delete button

## Test plan

- [x] 59 new tests across two files (`test_delete_bot.py`, `test_generic_delete_router.py`)
- [x] Covers: success (204), not-found (404), idempotency, ID validation (422), route naming, custom ID patterns, integration with create/update/list, response headers
- [x] Full test suite passes (398 passed, 1 skipped)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)