### PR TITLE
[backend] Add RBAC/Authorization to /bots CRUD endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ Assuming local server at `http://localhost:8000` and default API prefix `/api/v1
 ### Bot endpoints
 
 - `GET /api/v1/bots`
-- `POST /api/v1/bots`
+- `POST /api/v1/bots` *(admin only)*
 - `GET /api/v1/bots/{bot_id}`
-- `PUT /api/v1/bots/{bot_id}`
-- `DELETE /api/v1/bots/{bot_id}`
+- `PUT /api/v1/bots/{bot_id}` *(admin only)*
+- `DELETE /api/v1/bots/{bot_id}` *(admin only)*
 
 `GET /api/v1/bots` supports:
 

--- a/src/jm_api/api/deps.py
+++ b/src/jm_api/api/deps.py
@@ -177,4 +177,16 @@ def get_current_user(
 
 
 get_current_active_user = get_current_user
+
+
+def require_admin(current_user: User = Depends(get_current_active_user)) -> User:
+    """Require the current user to have admin privileges."""
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+    return current_user
+
+
 require_auth = get_current_active_user

--- a/src/jm_api/api/routes/bots.py
+++ b/src/jm_api/api/routes/bots.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from jm_api.api.deps import require_admin
 
 from jm_api.api.generic import (
     create_create_router,
@@ -59,6 +61,6 @@ _delete_router = create_delete_router(
 
 router = APIRouter()
 router.include_router(_read_router)
-router.include_router(_create_router)
-router.include_router(_update_router)
-router.include_router(_delete_router)
+router.include_router(_create_router, dependencies=[Depends(require_admin)])
+router.include_router(_update_router, dependencies=[Depends(require_admin)])
+router.include_router(_delete_router, dependencies=[Depends(require_admin)])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from jm_api.api.deps import create_access_token, hash_password
 from jm_api.db.base import Base
 from jm_api.models.bot import Bot
+from jm_api.models.user import User
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -85,9 +87,22 @@ def app(db_engine, db_session: Session) -> FastAPI:
 
 
 @pytest.fixture
-def client(app: FastAPI) -> TestClient:
-    """Create test client."""
-    return TestClient(app)
+def client(app: FastAPI, db_session: Session) -> TestClient:
+    """Create test client authenticated as an admin by default."""
+    admin = User(
+        email="default-admin@example.com",
+        password_hash=hash_password("password123"),
+        is_active=True,
+        is_admin=True,
+    )
+    db_session.add(admin)
+    db_session.commit()
+    db_session.refresh(admin)
+
+    token = create_access_token(admin.id)
+    client = TestClient(app)
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    return client
 
 
 @pytest.fixture
@@ -145,3 +160,43 @@ def bot_factory(db_session: Session):
         return bot
 
     return _create_bot
+
+
+@pytest.fixture
+def user_factory(db_session: Session):
+    """Factory fixture for creating users in tests."""
+
+    def _create_user(
+        email: str = "user@example.com",
+        password: str = "password123",
+        is_admin: bool = False,
+        is_active: bool = True,
+    ) -> User:
+        user = User(
+            email=email,
+            password_hash=hash_password(password),
+            is_active=is_active,
+            is_admin=is_admin,
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+        return user
+
+    return _create_user
+
+
+@pytest.fixture
+def admin_headers(user_factory) -> dict[str, str]:
+    """Authorization header for an admin user."""
+    admin = user_factory(email="admin@example.com", is_admin=True)
+    token = create_access_token(admin.id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def user_headers(user_factory) -> dict[str, str]:
+    """Authorization header for a non-admin user."""
+    user = user_factory(email="member@example.com", is_admin=False)
+    token = create_access_token(user.id)
+    return {"Authorization": f"Bearer {token}"}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -169,9 +169,9 @@ class TestMeEndpoint:
         assert data["is_active"] is True
         assert data["is_admin"] is False
 
-    def test_get_me_no_token(self, client: TestClient) -> None:
+    def test_get_me_no_token(self, app) -> None:
         """Test getting user info without token returns 401."""
-        response = client.get("/api/v1/auth/me")
+        response = TestClient(app).get("/api/v1/auth/me")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_get_me_invalid_token(self, client: TestClient) -> None:

--- a/tests/test_bots_rbac.py
+++ b/tests/test_bots_rbac.py
@@ -1,0 +1,48 @@
+"""RBAC tests for bots CRUD endpoints."""
+
+
+from fastapi.testclient import TestClient
+
+
+def test_create_bot_requires_auth(app) -> None:
+    unauthenticated_client = TestClient(app)
+    response = unauthenticated_client.post("/api/v1/bots", json={"rig_id": "rig-new"})
+    assert response.status_code == 401
+
+
+def test_create_bot_requires_admin(client, user_headers) -> None:
+    response = client.post(
+        "/api/v1/bots",
+        json={"rig_id": "rig-new"},
+        headers=user_headers,
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin privileges required"
+
+
+def test_create_bot_allows_admin(client, admin_headers) -> None:
+    response = client.post(
+        "/api/v1/bots",
+        json={"rig_id": "rig-new"},
+        headers=admin_headers,
+    )
+    assert response.status_code == 201
+
+
+def test_update_bot_requires_admin(client, bot_factory, user_headers) -> None:
+    bot = bot_factory(rig_id="rig-001")
+    response = client.put(
+        f"/api/v1/bots/{bot.id}",
+        json={"rig_id": "rig-002"},
+        headers=user_headers,
+    )
+    assert response.status_code == 403
+
+
+def test_delete_bot_requires_admin(client, bot_factory, user_headers) -> None:
+    bot = bot_factory(rig_id="rig-001")
+    response = client.delete(
+        f"/api/v1/bots/{bot.id}",
+        headers=user_headers,
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- enforce RBAC authorization on /bots CRUD write operations
- add reusable authorization dependency helpers for admin/manager checks
- add tests covering role-based access behavior for bots endpoints

## Testing
- .venv/bin/pytest -q

Closes #58
