### PR TITLE
[backend] Persist refresh-token revocation in session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,31 @@ All settings use the `JM_API_` prefix.
 - `JM_API_JWT_ACCESS_TOKEN_EXPIRE_MINUTES=15`
 - `JM_API_JWT_REFRESH_TOKEN_EXPIRE_DAYS=7`
 
+### Session store settings (refresh-token revocation)
+
+Refresh-token revocation is persisted in PostgreSQL/SQL via the `session_tokens` table.
+
+- `JM_API_SESSION_CLEANUP_INTERVAL_SECONDS=300` (opportunistic cleanup interval in API process)
+
+#### Migration
+
+Apply the SQL migration before deployment:
+
+```bash
+psql "$JM_API_DATABASE_URL" -f ops/migrations/20260218_add_session_tokens.sql
+```
+
+The migration creates a `session_tokens` table with:
+
+- `token_jti` (PK)
+- `user_id`
+- `issued_at`
+- `expires_at`
+- `revoked_at`
+- `rotated_from_jti`
+
+To keep revocation checks fast (<10ms target), ensure indexes from the migration are present.
+
 ### Observability settings
 
 - `JM_API_METRICS_ENABLED=true`
@@ -180,6 +205,7 @@ src/jm_api/
       bots.py          # bot CRUD routes
   models/
     bot.py
+    session_token.py
     user.py
   static/              # /admin frontend assets
 tests/

--- a/ops/migrations/20260218_add_session_tokens.sql
+++ b/ops/migrations/20260218_add_session_tokens.sql
@@ -1,0 +1,24 @@
+-- Issue #61: persistent refresh-token session store
+-- Apply this migration before deploying the new auth flow.
+
+CREATE TABLE IF NOT EXISTS session_tokens (
+    token_jti VARCHAR(64) PRIMARY KEY,
+    user_id VARCHAR(32) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    issued_at TIMESTAMPTZ NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ NULL,
+    rotated_from_jti VARCHAR(64) NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_session_tokens_user_id
+    ON session_tokens (user_id);
+
+CREATE INDEX IF NOT EXISTS ix_session_tokens_expires_at
+    ON session_tokens (expires_at);
+
+CREATE INDEX IF NOT EXISTS ix_session_tokens_rotated_from_jti
+    ON session_tokens (rotated_from_jti);
+
+-- Optional recurring cleanup job (PostgreSQL + pg_cron):
+-- SELECT cron.schedule('cleanup_expired_session_tokens', '*/10 * * * *',
+--   $$DELETE FROM session_tokens WHERE expires_at <= NOW()$$);

--- a/src/jm_api/api/deps.py
+++ b/src/jm_api/api/deps.py
@@ -9,43 +9,44 @@ import bcrypt
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import select
+from sqlalchemy import delete, select, update
 from sqlalchemy.orm import Session
 
 from jm_api.core.config import get_settings
 from jm_api.db.session import get_db
+from jm_api.models.session_token import SessionToken
 from jm_api.models.user import User
 from jm_api.schemas.auth import TokenPayload
 
 security = HTTPBearer(auto_error=False)
 
-# In-memory refresh token denylist (token -> exp timestamp)
-_REVOKED_REFRESH_TOKENS: dict[str, int] = {}
+_LAST_SESSION_CLEANUP_AT: datetime | None = None
 
 
-def _prune_expired_revoked_tokens() -> None:
-    now_ts = int(datetime.now(timezone.utc).timestamp())
-    expired_tokens = [token for token, exp in _REVOKED_REFRESH_TOKENS.items() if exp <= now_ts]
-    for token in expired_tokens:
-        _REVOKED_REFRESH_TOKENS.pop(token, None)
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
 
 
-def revoke_refresh_token(token: str) -> None:
-    """Revoke a refresh token until it expires."""
-    _prune_expired_revoked_tokens()
-    try:
-        payload = decode_token(token)
-    except HTTPException:
-        return
-
-    if payload.type == "refresh":
-        _REVOKED_REFRESH_TOKENS[token] = payload.exp
+def _normalize_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
 
 
-def is_refresh_token_revoked(token: str) -> bool:
-    """Check whether a refresh token has been revoked."""
-    _prune_expired_revoked_tokens()
-    return token in _REVOKED_REFRESH_TOKENS
+def _maybe_cleanup_expired_sessions(db: Session) -> None:
+    """Opportunistically cleanup expired session rows at a bounded interval."""
+    global _LAST_SESSION_CLEANUP_AT
+
+    settings = get_settings()
+    now = _utcnow()
+    if _LAST_SESSION_CLEANUP_AT is not None:
+        elapsed = (now - _LAST_SESSION_CLEANUP_AT).total_seconds()
+        if elapsed < settings.session_cleanup_interval_seconds:
+            return
+
+    db.execute(delete(SessionToken).where(SessionToken.expires_at <= now))
+    db.commit()
+    _LAST_SESSION_CLEANUP_AT = now
 
 
 def hash_password(password: str) -> str:
@@ -70,7 +71,7 @@ def create_access_token(user_id: str, expires_delta: timedelta | None = None) ->
     if expires_delta is None:
         expires_delta = timedelta(minutes=settings.jwt_access_token_expire_minutes)
 
-    now = datetime.now(timezone.utc)
+    now = _utcnow()
     expire = now + expires_delta
 
     payload = {
@@ -91,7 +92,7 @@ def create_refresh_token(user_id: str) -> str:
     """Create a JWT refresh token."""
     settings = get_settings()
 
-    now = datetime.now(timezone.utc)
+    now = _utcnow()
     expire = now + timedelta(days=settings.jwt_refresh_token_expire_days)
 
     payload = {
@@ -132,6 +133,82 @@ def decode_token(token: str) -> TokenPayload:
             detail="Invalid token",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+
+def _decode_refresh_token_payload(token: str) -> TokenPayload:
+    payload = decode_token(token)
+    if payload.type != "refresh" or payload.jti is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token type",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return payload
+
+
+def persist_refresh_token(db: Session, token: str, rotated_from_jti: str | None = None) -> None:
+    """Persist issued refresh token in session store."""
+    payload = _decode_refresh_token_payload(token)
+    issued_at = datetime.fromtimestamp(payload.iat, tz=timezone.utc)
+    expires_at = datetime.fromtimestamp(payload.exp, tz=timezone.utc)
+
+    existing = db.execute(
+        select(SessionToken).where(SessionToken.token_jti == payload.jti)
+    ).scalar_one_or_none()
+    if existing is None:
+        db.add(
+            SessionToken(
+                token_jti=payload.jti,
+                user_id=payload.sub,
+                issued_at=issued_at,
+                expires_at=expires_at,
+                revoked_at=None,
+                rotated_from_jti=rotated_from_jti,
+            )
+        )
+        db.commit()
+
+
+def revoke_refresh_token(db: Session, token: str) -> None:
+    """Mark refresh token as revoked in persistent store."""
+    try:
+        payload = _decode_refresh_token_payload(token)
+    except HTTPException:
+        return
+
+    now = _utcnow()
+    db.execute(
+        update(SessionToken)
+        .where(SessionToken.token_jti == payload.jti)
+        .values(revoked_at=now)
+    )
+    db.commit()
+
+
+def is_refresh_token_revoked(db: Session, token: str) -> bool:
+    """Check whether a refresh token is revoked or unknown in persistent store."""
+    payload = _decode_refresh_token_payload(token)
+    _maybe_cleanup_expired_sessions(db)
+
+    session_token = db.execute(
+        select(SessionToken).where(SessionToken.token_jti == payload.jti)
+    ).scalar_one_or_none()
+
+    if session_token is None:
+        return True
+
+    now = _utcnow()
+    if _normalize_utc(session_token.expires_at) <= now:
+        return True
+
+    return session_token.revoked_at is not None
+
+
+def get_refresh_token_jti(token: str) -> str:
+    """Get refresh token JTI."""
+    payload = _decode_refresh_token_payload(token)
+    assert payload.jti is not None
+    return payload.jti
 
 
 def get_current_user(

--- a/src/jm_api/api/routes/auth.py
+++ b/src/jm_api/api/routes/auth.py
@@ -14,8 +14,10 @@ from jm_api.api.deps import (
     create_refresh_token,
     decode_token,
     get_current_user,
+    get_refresh_token_jti,
     hash_password,
     is_refresh_token_revoked,
+    persist_refresh_token,
     revoke_refresh_token,
     verify_password,
 )
@@ -76,6 +78,7 @@ def login(
 
     access_token = create_access_token(user.id)
     refresh_token = create_refresh_token(user.id)
+    persist_refresh_token(db, refresh_token)
 
     settings = get_settings()
     logger.info(
@@ -174,7 +177,7 @@ def refresh_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    if is_refresh_token_revoked(token):
+    if is_refresh_token_revoked(db, token):
         logger.warning(
             "auth.refresh.failed",
             reason="refresh_token_revoked",
@@ -230,9 +233,11 @@ def refresh_token(
         )
 
     settings = get_settings()
+    old_jti = get_refresh_token_jti(token)
     new_access_token = create_access_token(user.id)
     new_refresh_token = create_refresh_token(user.id)
-    revoke_refresh_token(token)
+    revoke_refresh_token(db, token)
+    persist_refresh_token(db, new_refresh_token, rotated_from_jti=old_jti)
 
     response.set_cookie(
         key="refresh_token",
@@ -262,10 +267,11 @@ def logout(
     request: Request,
     response: Response,
     refresh_token_cookie: str | None = Cookie(None, alias="refresh_token"),
+    db: Session = Depends(get_db),
 ) -> None:
     """Logout user by revoking refresh token and clearing the refresh-token cookie."""
     if refresh_token_cookie is not None:
-        revoke_refresh_token(refresh_token_cookie)
+        revoke_refresh_token(db, refresh_token_cookie)
 
     logger.info(
         "auth.logout.success",

--- a/src/jm_api/core/config.py
+++ b/src/jm_api/core/config.py
@@ -72,6 +72,7 @@ class Settings(BaseSettings):
     jwt_algorithm: str = Field(default="HS256")
     jwt_access_token_expire_minutes: int = Field(default=15)
     jwt_refresh_token_expire_days: int = Field(default=7)
+    session_cleanup_interval_seconds: int = Field(default=300)
 
     model_config = SettingsConfigDict(
         env_prefix="JM_API_",

--- a/src/jm_api/models/__init__.py
+++ b/src/jm_api/models/__init__.py
@@ -1,4 +1,5 @@
 from jm_api.models.bot import Bot
+from jm_api.models.session_token import SessionToken
 from jm_api.models.user import User
 
-__all__ = ["Bot", "User"]
+__all__ = ["Bot", "SessionToken", "User"]

--- a/src/jm_api/models/session_token.py
+++ b/src/jm_api/models/session_token.py
@@ -1,0 +1,30 @@
+"""Persistent refresh-session token model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from jm_api.db.base import Base
+
+
+class SessionToken(Base):
+    """Stores refresh-token session state for revocation and rotation."""
+
+    __tablename__ = "session_tokens"
+
+    token_jti: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        String(32),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    issued_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rotated_from_jti: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)

--- a/src/jm_api/schemas/auth.py
+++ b/src/jm_api/schemas/auth.py
@@ -72,3 +72,4 @@ class TokenPayload(BaseModel):
     exp: int  # expiration timestamp
     iat: int  # issued at timestamp
     type: str  # "access" or "refresh"
+    jti: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from jm_api.api.deps import create_access_token, hash_password
 from jm_api.db.base import Base
 from jm_api.models.bot import Bot
+from jm_api.models.session_token import SessionToken as _SessionToken  # noqa: F401
 from jm_api.models.user import User
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from jm_api.core.config import get_settings
 from jm_api.db.base import Base
+from jm_api.models.session_token import SessionToken as _SessionToken  # noqa: F401
 
 _SQLITE_PATH = Path("/tmp/jm_integration_test.db")
 _DATABASE_URL = f"sqlite:///{_SQLITE_PATH}"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from jm_api.api.deps import hash_password, verify_password
+from jm_api.models.session_token import SessionToken
 from jm_api.models.user import User
 
 
@@ -61,7 +62,7 @@ class TestPasswordHashing:
 class TestLoginEndpoint:
     """Test the login endpoint."""
 
-    def test_login_success(self, client: TestClient, test_user: User) -> None:
+    def test_login_success(self, client: TestClient, test_user: User, db_session: Session) -> None:
         """Test successful login returns tokens."""
         response = client.post(
             "/api/v1/auth/login",
@@ -77,6 +78,12 @@ class TestLoginEndpoint:
         assert data["token_type"] == "bearer"
         assert data["expires_in"] == 900  # 15 minutes
         assert "refresh_token" in response.cookies
+
+        refresh_session = db_session.execute(
+            select(SessionToken).where(SessionToken.user_id == test_user.id)
+        ).scalar_one_or_none()
+        assert refresh_session is not None
+        assert refresh_session.revoked_at is None
 
     def test_login_invalid_email(self, client: TestClient, test_user: User) -> None:
         """Test login with invalid email returns 401."""
@@ -205,7 +212,12 @@ class TestRefreshEndpoint:
         assert "refresh_token" in data
         assert data["token_type"] == "bearer"
 
-    def test_refresh_token_from_cookie(self, client: TestClient, test_user: User) -> None:
+    def test_refresh_token_from_cookie(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
         """Test refreshing tokens rotates refresh cookie."""
         # First login to set the cookie
         login_response = client.post(
@@ -225,6 +237,15 @@ class TestRefreshEndpoint:
         assert "refresh_token" in data
         assert data["refresh_token"] != old_refresh_token
         assert client.cookies.get("refresh_token") == data["refresh_token"]
+
+        sessions = db_session.execute(select(SessionToken)).scalars().all()
+        assert len(sessions) == 2
+
+        revoked_old = [s for s in sessions if s.revoked_at is not None]
+        active_new = [s for s in sessions if s.revoked_at is None]
+        assert len(revoked_old) == 1
+        assert len(active_new) == 1
+        assert active_new[0].rotated_from_jti == revoked_old[0].token_jti
 
     def test_refresh_no_token(self, client: TestClient) -> None:
         """Test refresh without token returns 401."""
@@ -258,7 +279,12 @@ class TestLogoutEndpoint:
         response = client.post("/api/v1/auth/logout")
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    def test_logout_revokes_current_refresh_token(self, client: TestClient, test_user: User) -> None:
+    def test_logout_revokes_current_refresh_token(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
         """Test logout revokes the refresh token used for the session."""
         login_response = client.post(
             "/api/v1/auth/login",
@@ -271,6 +297,11 @@ class TestLogoutEndpoint:
 
         response = client.post("/api/v1/auth/logout")
         assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        revoked_rows = db_session.execute(
+            select(SessionToken).where(SessionToken.revoked_at.is_not(None))
+        ).scalars().all()
+        assert len(revoked_rows) >= 1
 
         # Try to reuse the revoked token directly
         client.cookies.set("refresh_token", refresh_token)


### PR DESCRIPTION
## Summary
- replace in-memory refresh-token denylist with persistent `session_tokens` store
- persist issued refresh tokens and mark them revoked on logout/rotation
- track rotation via `rotated_from_jti`
- add opportunistic cleanup of expired sessions and DB migration SQL
- update README with session store config and migration instructions

## Details
- Added `SessionToken` model with fields: `token_jti`, `user_id`, `issued_at`, `expires_at`, `revoked_at`, `rotated_from_jti`
- Updated auth flow:
  - `/auth/login` persists refresh token session
  - `/auth/refresh` checks persistent revocation status before issuing new tokens
  - `/auth/refresh` revokes old token and stores rotated token with lineage
  - `/auth/logout` revokes refresh token in persistent store
- Added migration script: `ops/migrations/20260218_add_session_tokens.sql`
- Added config: `JM_API_SESSION_CLEANUP_INTERVAL_SECONDS`
- Extended auth tests for persistent session creation, revocation, and rotation linkage

## Validation
- `uv run pytest tests/test_auth.py`

Closes #61
