### PR TITLE
[backend] Security hardening: token rotation, error handling, and validation

### DIFF
--- a/src/jm_api/api/deps.py
+++ b/src/jm_api/api/deps.py
@@ -9,7 +9,9 @@ import bcrypt
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import ValidationError
 from sqlalchemy import delete, select, update
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from jm_api.core.config import get_settings
@@ -44,9 +46,12 @@ def _maybe_cleanup_expired_sessions(db: Session) -> None:
         if elapsed < settings.session_cleanup_interval_seconds:
             return
 
-    db.execute(delete(SessionToken).where(SessionToken.expires_at <= now))
-    db.commit()
-    _LAST_SESSION_CLEANUP_AT = now
+    try:
+        db.execute(delete(SessionToken).where(SessionToken.expires_at <= now))
+        db.commit()
+        _LAST_SESSION_CLEANUP_AT = now
+    except Exception:
+        db.rollback()
 
 
 def hash_password(password: str) -> str:
@@ -127,7 +132,7 @@ def decode_token(token: str) -> TokenPayload:
             detail="Token has expired",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    except jwt.InvalidTokenError:
+    except (jwt.InvalidTokenError, ValidationError):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token",
@@ -152,21 +157,27 @@ def persist_refresh_token(db: Session, token: str, rotated_from_jti: str | None 
     issued_at = datetime.fromtimestamp(payload.iat, tz=timezone.utc)
     expires_at = datetime.fromtimestamp(payload.exp, tz=timezone.utc)
 
-    existing = db.execute(
-        select(SessionToken).where(SessionToken.token_jti == payload.jti)
-    ).scalar_one_or_none()
-    if existing is None:
-        db.add(
-            SessionToken(
-                token_jti=payload.jti,
-                user_id=payload.sub,
-                issued_at=issued_at,
-                expires_at=expires_at,
-                revoked_at=None,
-                rotated_from_jti=rotated_from_jti,
-            )
+    db.add(
+        SessionToken(
+            token_jti=payload.jti,
+            user_id=payload.sub,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            revoked_at=None,
+            rotated_from_jti=rotated_from_jti,
         )
+    )
+    try:
         db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Token ID collision - retry",
+        )
+    except SQLAlchemyError:
+        db.rollback()
+        raise
 
 
 def revoke_refresh_token(db: Session, token: str) -> None:
@@ -177,12 +188,52 @@ def revoke_refresh_token(db: Session, token: str) -> None:
         return
 
     now = _utcnow()
-    db.execute(
-        update(SessionToken)
-        .where(SessionToken.token_jti == payload.jti)
-        .values(revoked_at=now)
-    )
-    db.commit()
+    try:
+        db.execute(
+            update(SessionToken)
+            .where(SessionToken.token_jti == payload.jti)
+            .values(revoked_at=now)
+        )
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
+
+
+def revoke_user_sessions(db: Session, user_id: str) -> None:
+    """Revoke all active refresh sessions for a user (token-reuse hardening)."""
+    now = _utcnow()
+    try:
+        db.execute(
+            update(SessionToken)
+            .where(SessionToken.user_id == user_id)
+            .where(SessionToken.revoked_at.is_(None))
+            .values(revoked_at=now)
+        )
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
+
+
+def consume_refresh_token(db: Session, token: str) -> bool:
+    """Atomically consume (revoke) an active refresh token once."""
+    payload = _decode_refresh_token_payload(token)
+    now = _utcnow()
+
+    try:
+        result = db.execute(
+            update(SessionToken)
+            .where(SessionToken.token_jti == payload.jti)
+            .where(SessionToken.revoked_at.is_(None))
+            .values(revoked_at=now)
+        )
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        raise
+
+    return bool(result.rowcount)
 
 
 def is_refresh_token_revoked(db: Session, token: str) -> bool:
@@ -196,6 +247,13 @@ def is_refresh_token_revoked(db: Session, token: str) -> bool:
 
     if session_token is None:
         return True
+
+    if session_token.user_id != payload.sub:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token mismatch",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     now = _utcnow()
     if _normalize_utc(session_token.expires_at) <= now:

--- a/src/jm_api/api/routes/auth.py
+++ b/src/jm_api/api/routes/auth.py
@@ -7,10 +7,12 @@ from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from jm_api.api.deps import (
     create_access_token,
+    consume_refresh_token,
     create_refresh_token,
     decode_token,
     get_current_user,
@@ -19,6 +21,7 @@ from jm_api.api.deps import (
     is_refresh_token_revoked,
     persist_refresh_token,
     revoke_refresh_token,
+    revoke_user_sessions,
     verify_password,
 )
 from jm_api.core.config import get_settings
@@ -78,7 +81,19 @@ def login(
 
     access_token = create_access_token(user.id)
     refresh_token = create_refresh_token(user.id)
-    persist_refresh_token(db, refresh_token)
+    try:
+        persist_refresh_token(db, refresh_token)
+    except SQLAlchemyError:
+        logger.exception(
+            "auth.login.failed",
+            reason="session_persist_error",
+            user_id=user.id,
+            request_id=_request_id(request),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Authentication service unavailable",
+        )
 
     settings = get_settings()
     logger.info(
@@ -142,7 +157,20 @@ def signup(
     )
 
     db.add(new_user)
-    db.commit()
+    try:
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        logger.exception(
+            "auth.signup.failed",
+            reason="database_error",
+            email=user_data.email,
+            request_id=_request_id(request),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Unable to create user",
+        )
     db.refresh(new_user)
 
     logger.info(
@@ -177,7 +205,38 @@ def refresh_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    if is_refresh_token_revoked(db, token):
+    try:
+        refresh_revoked = is_refresh_token_revoked(db, token)
+    except SQLAlchemyError:
+        logger.exception(
+            "auth.refresh.failed",
+            reason="session_lookup_error",
+            request_id=_request_id(request),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Authentication service unavailable",
+        )
+
+    if refresh_revoked:
+        # Token replay hardening: if we can decode the token, revoke all active
+        # sessions for that user to force full re-authentication.
+        try:
+            revoked_payload = decode_token(token)
+        except HTTPException:
+            revoked_payload = None
+
+        if revoked_payload is not None and revoked_payload.type == "refresh":
+            try:
+                revoke_user_sessions(db, revoked_payload.sub)
+            except SQLAlchemyError:
+                logger.exception(
+                    "auth.refresh.failed",
+                    reason="replay_containment_error",
+                    user_id=revoked_payload.sub,
+                    request_id=_request_id(request),
+                )
+
         logger.warning(
             "auth.refresh.failed",
             reason="refresh_token_revoked",
@@ -236,8 +295,32 @@ def refresh_token(
     old_jti = get_refresh_token_jti(token)
     new_access_token = create_access_token(user.id)
     new_refresh_token = create_refresh_token(user.id)
-    revoke_refresh_token(db, token)
-    persist_refresh_token(db, new_refresh_token, rotated_from_jti=old_jti)
+    try:
+        token_consumed = consume_refresh_token(db, token)
+        if not token_consumed:
+            logger.warning(
+                "auth.refresh.failed",
+                reason="token_already_consumed",
+                user_id=user.id,
+                request_id=_request_id(request),
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Token already revoked or consumed",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        persist_refresh_token(db, new_refresh_token, rotated_from_jti=old_jti)
+    except SQLAlchemyError:
+        logger.exception(
+            "auth.refresh.failed",
+            reason="session_rotation_error",
+            user_id=user.id,
+            request_id=_request_id(request),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Authentication service unavailable",
+        )
 
     response.set_cookie(
         key="refresh_token",
@@ -271,7 +354,14 @@ def logout(
 ) -> None:
     """Logout user by revoking refresh token and clearing the refresh-token cookie."""
     if refresh_token_cookie is not None:
-        revoke_refresh_token(db, refresh_token_cookie)
+        try:
+            revoke_refresh_token(db, refresh_token_cookie)
+        except SQLAlchemyError:
+            logger.exception(
+                "auth.logout.failed",
+                reason="session_revoke_error",
+                request_id=_request_id(request),
+            )
 
     logger.info(
         "auth.logout.success",

--- a/src/jm_api/schemas/auth.py
+++ b/src/jm_api/schemas/auth.py
@@ -27,7 +27,7 @@ class LoginRequest(BaseModel):
     """Login request schema."""
 
     email: EmailStr
-    password: str
+    password: str = Field(..., min_length=8, max_length=128)
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import jwt
 import pytest
-from fastapi import status
+from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
-from jm_api.api.deps import hash_password, verify_password
+from jm_api.api import deps as auth_deps
+from jm_api.api.deps import hash_password, persist_refresh_token, verify_password
+from jm_api.core.config import get_settings
 from jm_api.models.session_token import SessionToken
 from jm_api.models.user import User
 
@@ -148,6 +151,14 @@ class TestLoginEndpoint:
         )
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    def test_login_short_password_returns_422(self, client: TestClient) -> None:
+        """Login payload enforces minimum password length."""
+        response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "short"},
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 class TestMeEndpoint:
     """Test the /me endpoint."""
@@ -258,6 +269,134 @@ class TestRefreshEndpoint:
         client.cookies.set("refresh_token", "invalid_token")
         response = client.post("/api/v1/auth/refresh")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_refresh_malformed_payload_returns_401(
+        self,
+        client: TestClient,
+        test_user: User,
+    ) -> None:
+        """Malformed JWT payload should return 401 and never 500."""
+        settings = get_settings()
+        malformed_refresh = jwt.encode(
+            {
+                "sub": test_user.id,
+                "type": "refresh",
+                "exp": "not-an-int",
+                "iat": "not-an-int",
+            },
+            settings.jwt_secret_key,
+            algorithm=settings.jwt_algorithm,
+        )
+        client.cookies.set("refresh_token", malformed_refresh)
+        response = client.post("/api/v1/auth/refresh")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_refresh_token_reuse_revokes_all_sessions(
+        self,
+        client: TestClient,
+        test_user: User,
+        db_session: Session,
+    ) -> None:
+        """Reusing a rotated/revoked refresh token revokes all user sessions."""
+        login_response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+        first_refresh = login_response.json()["refresh_token"]
+
+        rotate_response = client.post("/api/v1/auth/refresh")
+        assert rotate_response.status_code == status.HTTP_200_OK
+
+        # Attempt replay with the old token
+        client.cookies.set("refresh_token", first_refresh)
+        replay_response = client.post("/api/v1/auth/refresh")
+        assert replay_response.status_code == status.HTTP_401_UNAUTHORIZED
+
+        active_sessions = db_session.execute(
+            select(SessionToken).where(
+                SessionToken.user_id == test_user.id,
+                SessionToken.revoked_at.is_(None),
+            )
+        ).scalars().all()
+        assert len(active_sessions) == 0
+
+
+class TestSecurityHardening:
+    """Security hardening tests for token/session edge cases."""
+
+    def test_refresh_token_rotation_race_second_consume_fails(
+        self,
+        client: TestClient,
+        test_user: User,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If token was already consumed concurrently, refresh returns 401."""
+        client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+
+        monkeypatch.setattr("jm_api.api.routes.auth.consume_refresh_token", lambda db, token: False)
+        response = client.post("/api/v1/auth/refresh")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "consumed" in response.json()["detail"].lower()
+
+    def test_cleanup_errors_are_swallowed(self, db_session: Session) -> None:
+        """Cleanup is opportunistic and should never raise."""
+
+        class FailingSession:
+            def execute(self, *_args, **_kwargs):
+                raise RuntimeError("db lock")
+
+            def commit(self):
+                return None
+
+            def rollback(self):
+                return None
+
+        auth_deps._maybe_cleanup_expired_sessions(FailingSession())
+
+    def test_persist_refresh_token_jti_collision_returns_400(
+        self,
+        db_session: Session,
+        test_user: User,
+    ) -> None:
+        """Duplicate JTI insertion returns a safe 400 response."""
+        token = auth_deps.create_refresh_token(test_user.id)
+        persist_refresh_token(db_session, token)
+
+        with pytest.raises(HTTPException) as exc_info:
+            persist_refresh_token(db_session, token)
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "collision" in exc_info.value.detail.lower()
+
+    def test_refresh_token_user_mismatch_returns_401(
+        self,
+        client: TestClient,
+        db_session: Session,
+        test_user: User,
+        user_factory,
+    ) -> None:
+        """JWT sub must match persisted session user_id."""
+        login_response = client.post(
+            "/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "securepassword123"},
+        )
+        refresh_token = login_response.json()["refresh_token"]
+        jti = auth_deps.get_refresh_token_jti(refresh_token)
+
+        other_user = user_factory(email="other@example.com")
+        db_session.execute(
+            update(SessionToken)
+            .where(SessionToken.token_jti == jti)
+            .values(user_id=other_user.id)
+        )
+        db_session.commit()
+
+        response = client.post("/api/v1/auth/refresh")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "mismatch" in response.json()["detail"].lower()
 
 
 class TestLogoutEndpoint:


### PR DESCRIPTION
## Summary\n- harden refresh token rotation with atomic consume semantics to prevent replay/race reuse\n- add defensive DB error handling across auth login/signup/refresh/logout flows\n- tighten login payload validation and token payload/session consistency checks\n- add coverage for malformed payloads, replay containment, collisions, and mismatch edge cases\n\nFixes #63.