### PR TITLE
Add gunicorn + uvicorn worker configuration for production resilience

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn jm_api.main:app --host 0.0.0.0 --port $PORT
+web: gunicorn jm_api.main:app --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$PORT --workers ${WEB_CONCURRENCY:-2} --timeout ${GUNICORN_TIMEOUT:-60} --graceful-timeout ${GUNICORN_GRACEFUL_TIMEOUT:-30} --keep-alive ${GUNICORN_KEEP_ALIVE:-5} --max-requests ${GUNICORN_MAX_REQUESTS:-1000} --max-requests-jitter ${GUNICORN_MAX_REQUESTS_JITTER:-100}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ Current functionality includes:
    uv run uvicorn jm_api.main:app --reload
    ```
 
+   **Production process model (Procfile):**
+
+   ```bash
+   gunicorn jm_api.main:app \
+     --worker-class uvicorn.workers.UvicornWorker \
+     --bind 0.0.0.0:${PORT:-8000} \
+     --workers ${WEB_CONCURRENCY:-2}
+   ```
+
 4. **Open the app**
    - API docs: http://localhost:8000/docs
    - Admin UI: http://localhost:8000/admin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "psycopg2-binary>=2.9",
   "pydantic-settings>=2.2",
   "sqlalchemy>=2.0",
+  "gunicorn>=22.0",
   "uvicorn[standard]>=0.27",
   "bcrypt>=4.0",
   "pyjwt>=2.8",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ fastapi==0.128.0
     # via jm-api
 greenlet==3.3.1 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
     # via sqlalchemy
+gunicorn==25.1.0
+    # via jm-api
 h11==0.16.0
     # via uvicorn
 httptools==0.7.1

--- a/tests/test_heroku_deployment.py
+++ b/tests/test_heroku_deployment.py
@@ -15,9 +15,10 @@ class TestProcfile:
         content = (ROOT / "Procfile").read_text()
         assert content.startswith("web:")
 
-    def test_procfile_uses_uvicorn(self):
+    def test_procfile_uses_gunicorn_with_uvicorn_worker(self):
         content = (ROOT / "Procfile").read_text()
-        assert "uvicorn" in content
+        assert "gunicorn" in content
+        assert "uvicorn.workers.UvicornWorker" in content
 
     def test_procfile_references_app_entry_point(self):
         content = (ROOT / "Procfile").read_text()
@@ -83,6 +84,6 @@ class TestRequirementsTxt:
         assert "psycopg2" in content or "psycopg" in content
 
     def test_requirements_txt_contains_gunicorn(self):
-        """Gunicorn is the recommended WSGI/ASGI process manager on Heroku."""
+        """Gunicorn should be available as the production process manager."""
         content = (ROOT / "requirements.txt").read_text().lower()
-        assert "gunicorn" in content or "uvicorn" in content
+        assert "gunicorn" in content

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/13/ef67f59f6a7896fdc2c1d62b5665c5219d6b0a9a1784938eb9a28e55e128/gunicorn-25.1.0.tar.gz", hash = "sha256:1426611d959fa77e7de89f8c0f32eed6aa03ee735f98c01efba3e281b1c47616", size = 594377, upload-time = "2026-02-13T11:09:58.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/73/4ad5b1f6a2e21cf1e85afdaad2b7b1a933985e2f5d679147a1953aaa192c/gunicorn-25.1.0-py3-none-any.whl", hash = "sha256:d0b1236ccf27f72cfe14bce7caadf467186f19e865094ca84221424e839b8b8b", size = 197067, upload-time = "2026-02-13T11:09:57.146Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -364,6 +376,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "email-validator" },
     { name = "fastapi" },
+    { name = "gunicorn" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-jaeger-thrift" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -398,6 +411,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.110" },
+    { name = "gunicorn", specifier = ">=22.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "opentelemetry-api", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-jaeger-thrift", specifier = ">=1.21.0" },


### PR DESCRIPTION
## Summary
This PR updates the production process configuration to run the FastAPI app behind **Gunicorn** using **Uvicorn workers**, improving runtime resilience under load and enabling safer worker lifecycle controls.

## What changed
- Switched `Procfile` web command from raw `uvicorn` to:
  - `gunicorn jm_api.main:app`
  - `--worker-class uvicorn.workers.UvicornWorker`
  - configurable worker/process controls (`WEB_CONCURRENCY`, timeout, graceful-timeout, keep-alive, max-requests, max-requests-jitter)
- Added `gunicorn` to project dependencies:
  - `pyproject.toml`
  - `uv.lock`
  - `requirements.txt`
- Updated deployment tests to validate the new production contract:
  - Procfile uses gunicorn + uvicorn worker class
  - requirements include gunicorn
- Updated README quickstart section with the production process model snippet.

## Validation
- `uv run pytest tests/test_heroku_deployment.py`
- `uv run ruff check .`

## Notes
- Procfile continues to bind to `0.0.0.0:$PORT` for platform compatibility.
- Worker/process flags are env-configurable for operational tuning.

Fixes #72
