### PR TITLE
Add POST /api/admin/break endpoint for testing failure scenarios

### DIFF
--- a/src/jm_api/api/routes/health.py
+++ b/src/jm_api/api/routes/health.py
@@ -20,7 +20,7 @@ def liveness_check() -> dict[str, str]:
     if is_health_break_triggered():
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"status": "fail", "error": "artificial health check failure triggered"},
+            content={"status": "fail", "error": "artificial_failure_enabled"},
         )
     return {"status": "ok"}
 
@@ -31,7 +31,7 @@ def health_check(request: Request) -> JSONResponse:
     if is_health_break_triggered():
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"status": "fail", "error": "artificial health check failure triggered"},
+            content={"status": "fail", "error": "artificial_failure_enabled"},
         )
     payload, code = _build_deep_health_payload(request)
     return JSONResponse(status_code=code, content=payload)
@@ -43,7 +43,7 @@ def readiness_check(request: Request) -> JSONResponse:
     if is_health_break_triggered():
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"status": "fail", "error": "artificial health check failure triggered"},
+            content={"status": "fail", "error": "artificial_failure_enabled"},
         )
     payload, code = _build_deep_health_payload(request)
     return JSONResponse(status_code=code, content=payload)

--- a/tests/test_admin_break.py
+++ b/tests/test_admin_break.py
@@ -128,7 +128,7 @@ class TestAdminBreakTrigger:
         assert response.status_code == 500
         body = response.json()
         assert body["status"] == "fail"
-        assert "artificial health check failure triggered" in body["error"]
+        assert body["error"] == "artificial_failure_enabled"
 
     def test_break_causes_ready_to_return_500(self, client: TestClient, admin_user_factory, monkeypatch) -> None:
         """Ready endpoint returns 500 when break is triggered."""
@@ -151,7 +151,7 @@ class TestAdminBreakTrigger:
         assert response.status_code == 500
         body = response.json()
         assert body["status"] == "fail"
-        assert "artificial health check failure triggered" in body["error"]
+        assert body["error"] == "artificial_failure_enabled"
 
     def test_break_causes_live_to_return_500(self, client: TestClient, admin_user_factory) -> None:
         """Live endpoint returns 500 when break is triggered."""
@@ -169,7 +169,7 @@ class TestAdminBreakTrigger:
         assert response.status_code == 500
         body = response.json()
         assert body["status"] == "fail"
-        assert "artificial health check failure triggered" in body["error"]
+        assert body["error"] == "artificial_failure_enabled"
 
     def test_break_causes_healthz_to_return_ok(self, client: TestClient, admin_user_factory) -> None:
         """Healthz (legacy) endpoint is NOT affected by break - remains OK."""


### PR DESCRIPTION
## Summary

Implements issue #98: Adds an admin endpoint to artificially trigger health check failures for testing failure detection, pipeline handling, and rollback logic.

## Changes
- **POST /api/v1/admin/break** - Triggers artificial health check failure (admin-only)
- **POST /api/v1/admin/break/reset** - Resets health check failure (admin-only)
- **GET /api/v1/admin/break/status** - Gets current break status (admin-only)
- Updated health endpoints (/live, /health, /ready) to return 500 with error message `artificial_failure_enabled` when break is triggered

## Implementation Details
- Uses in-memory flag that resets on application restart
- Protected by admin authentication via `require_admin` dependency
- Error message standardized to `artificial_failure_enabled` as per requirements

## Testing
- All 592 tests pass
- Includes comprehensive test coverage in `test_admin_break.py`

Fixes #98