### PR TITLE
chore(deploy): temporarily hardcode Heroku app name for debugging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,9 @@ jobs:
         uses: akhileshns/heroku-deploy@v3.14.15
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
+          # TEMPORARY: Hardcoded for debugging CD pipeline
+          # TODO: Revert to secrets.HEROKU_APP_NAME after debugging
+          heroku_app_name: jm-api
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           branch: main
 


### PR DESCRIPTION
## Summary
Temporarily hardcodes the Heroku app name in the deploy.yml workflow to debug CD pipeline issues.

## Changes
- Updated `.github/workflows/deploy.yml` to hardcode `heroku_app_name: jm-api`
- Added TEMPORARY comments explaining the debugging purpose
- Added TODO comment for reverting back to secrets after debugging

## Testing
- ✅ YAML syntax validated
- ✅ 16 Heroku deployment tests passed

## Notes
This is a **temporary debugging change** and will be reverted in a follow-up issue after the CD pipeline issues are resolved.

Fixes #111