### PR TITLE
Fix Deploy: Remove Hardcode and Add Heroku CLI Install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,15 +21,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Deploy to Heroku
-        uses: akhileshns/heroku-deploy@v3.14.15
-        with:
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          # TEMPORARY: Hardcoded for debugging CD pipeline
-          # TODO: Revert to secrets.HEROKU_APP_NAME after debugging
-          heroku_app_name: jm-api
-          heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          branch: main
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Deploy
+        run: |
+          git push https://heroku:${{ secrets.HEROKU_API_KEY }}@git.heroku.com/${{ secrets.HEROKU_APP_NAME }}.git HEAD:main
 
       - name: Verify deployment health
         run: |


### PR DESCRIPTION
## Summary

Reverts the temporary hardcoded Heroku app name and adds manual Heroku CLI installation to fix first-run deployment issues.

## Changes

### 1. Reverted app name to use secrets
- Changed from hardcoded `jm-api` to `${{ secrets.HEROKU_APP_NAME }}`

### 2. Added Heroku CLI installation and manual deploy steps
- Added step to install Heroku CLI using the official install script
- Replaced the `akhileshns/heroku-deploy` GitHub Action with manual git push deployment
- This ensures deployments work on first run (fresh app) where no prior deployments had been made

## Why This Fix Is Needed

The previous deploy file using the third-party GitHub Action fails on the first run only because no prior deployments had been made. The manual git push approach with Heroku CLI installation ensures the first deployment succeeds.

## Testing
- Workflow syntax validated
- Existing tests pass (no code changes, only deployment configuration)

Fixes #113