### PR TITLE
Add verbose logging to CD deployment step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,8 @@ jobs:
         env:
           HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
         run: |
-          git push https://git.heroku.com/${HEROKU_APP_NAME}.git HEAD:main
+          set -x
+          GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push https://git.heroku.com/${HEROKU_APP_NAME}.git HEAD:main
 
       - name: Verify deployment health
         run: |


### PR DESCRIPTION
## Summary

Adds verbose logging to the CD deployment step to diagnose git push failures.

## Changes

Updated `.github/workflows/deploy.yml` to include debug flags in the Deploy to Heroku step:
- `set -x` — Print each command before execution
- `GIT_TRACE=1` — Enable Git trace logging
- `GIT_CURL_VERBOSE=1` — Verbose HTTP/HTTPS debug output

## Benefits
- Detailed visibility into git operations during deployment
- HTTP/HTTPS request details visible in CI logs
- Sufficient information to diagnose deployment failures

Fixes #117