### PR TITLE
fix(deploy): fetch full git history in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure netrc
         env:


### PR DESCRIPTION
## Summary

Updates the checkout action in `deploy.yml` to fetch full git history by adding `fetch-depth: 0`.

## Changes
- Added `fetch-depth: 0` to the actions/checkout step in `.github/workflows/deploy.yml`

## Why

Fetching full history is needed for operations that require complete git history, such as:
- Generating changelogs
- Version calculations
- Semantic versioning

Fixes #121