### PR TITLE
Move httpx from dev to production dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ dependencies = [
   "opentelemetry-exporter-jaeger-thrift>=1.21.0",
   "opentelemetry-instrumentation-fastapi>=0.48b0",
   "opentelemetry-instrumentation-sqlalchemy>=0.48b0",
+  "httpx>=0.27",
 ]
 
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0",
   "pytest-asyncio>=0.23",
-  "httpx>=0.27",
   "ruff>=0.3",
   "mypy>=1.10",
   "bandit>=1.7",
@@ -60,7 +60,6 @@ disable_error_code = ["arg-type", "attr-defined", "call-arg", "list-item", "retu
 
 [dependency-groups]
 dev = [
-    "httpx>=0.28.1",
     "pytest>=9.0.2",
     "ruff>=0.12.10",
     "mypy>=1.18.2",

--- a/uv.lock
+++ b/uv.lock
@@ -526,6 +526,7 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "gunicorn" },
+    { name = "httpx" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-jaeger-thrift" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -544,7 +545,6 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "bandit" },
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pytest" },
@@ -555,7 +555,6 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pytest" },
@@ -570,7 +569,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "gunicorn", specifier = ">=22.0" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "opentelemetry-api", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-jaeger-thrift", specifier = ">=1.21.0" },
@@ -595,7 +594,6 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.8.6" },
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pip-audit", specifier = ">=2.9.0" },
     { name = "pytest", specifier = ">=9.0.2" },


### PR DESCRIPTION
## Summary

Moves `httpx` from development-only dependencies to production dependencies in `pyproject.toml`.

## Problem
- `httpx` was listed only under `[project.optional-dependencies] dev` and `[dependency-groups] dev`
- Heroku only installs main dependencies, not dev/optional deps
- `webhooks.py` imports `httpx` at runtime, causing import errors in production

## Changes
- Added `httpx>=0.27` to `[project] dependencies`
- Removed `httpx` from `[project.optional-dependencies] dev`
- Removed `httpx` from `[dependency-groups] dev`
- Updated `uv.lock` with `uv lock`

## Verification
- Verified `httpx` imports successfully in production environment
- Verified `webhooks` module imports without errors
- `httpx` is still available for development via transitive dependency

Fixes #129