### PR TITLE
test: remove redundant/low-value test assertions

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -152,47 +152,7 @@ class TestDatabaseUrlConfig:
 
 
 class TestProductionSecurityInvariants:
-    """Production/staging fail-fast invariant checks."""
-
-    def test_rate_limit_storage_memory_not_allowed_in_production(self) -> None:
-        with pytest.raises(ValueError, match="JM_API_RATE_LIMIT_STORAGE_URI cannot be memory://"):
-            Settings(
-                environment="production",
-                database_url="postgresql://user:pass@localhost/proddb",
-                jwt_secret_key="x" * 32,
-                rate_limit_storage_uri="memory://",
-            )
-
-    def test_bots_write_admin_only_required_in_production(self) -> None:
-        with pytest.raises(ValueError, match="JM_API_BOTS_WRITE_ADMIN_ONLY must be true"):
-            Settings(
-                environment="production",
-                database_url="postgresql://user:pass@localhost/proddb",
-                jwt_secret_key="x" * 32,
-                rate_limit_storage_uri="redis://localhost:6379/0",
-                bots_write_admin_only=False,
-            )
-
-    def test_bots_write_admin_only_allows_explicit_risk_acknowledgement(self) -> None:
-        settings = Settings(
-            environment="production",
-            database_url="postgresql://user:pass@localhost/proddb",
-            jwt_secret_key="x" * 32,
-            rate_limit_storage_uri="redis://localhost:6379/0",
-            bots_write_admin_only=False,
-            i_understand_risk=True,
-        )
-        assert settings.i_understand_risk is True
-
-    def test_trust_proxy_headers_requires_trusted_proxy_cidrs(self) -> None:
-        with pytest.raises(ValueError, match="JM_API_TRUST_PROXY_HEADERS=true requires"):
-            Settings(
-                environment="production",
-                database_url="postgresql://user:pass@localhost/proddb",
-                jwt_secret_key="x" * 32,
-                rate_limit_storage_uri="redis://localhost:6379/0",
-                trust_proxy_headers=True,
-            )
+    """Production/staging fail-fast invariant checks not already covered above."""
 
     def test_invalid_trusted_proxy_cidrs_rejected(self) -> None:
         with pytest.raises(ValueError, match="Invalid proxy CIDR"):
@@ -200,15 +160,6 @@ class TestProductionSecurityInvariants:
                 environment="development",
                 database_url="sqlite:///:memory:",
                 trusted_proxy_cidrs=["not-a-cidr"],
-            )
-
-    def test_jwt_secret_must_be_32_bytes_in_production(self) -> None:
-        with pytest.raises(ValueError, match="JM_API_JWT_SECRET_KEY must be at least 32 bytes"):
-            Settings(
-                environment="production",
-                database_url="postgresql://user:pass@localhost/proddb",
-                jwt_secret_key="short-secret",
-                rate_limit_storage_uri="redis://localhost:6379/0",
             )
 
     def test_jwt_signing_keys_must_be_32_bytes_in_production(self) -> None:
@@ -220,17 +171,6 @@ class TestProductionSecurityInvariants:
                 jwt_signing_keys=["x" * 32, "too-short"],
                 rate_limit_storage_uri="redis://localhost:6379/0",
             )
-
-    def test_non_production_can_use_convenience_defaults(self) -> None:
-        settings = Settings(
-            environment="development",
-            database_url="sqlite:///:memory:",
-            jwt_secret_key="short",
-            rate_limit_storage_uri="memory://",
-            bots_write_admin_only=False,
-            trust_proxy_headers=True,
-        )
-        assert settings.environment == "development"
 
 
 class TestEnvironmentDefaults:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,7 +16,6 @@ def test_bot_id_generated_and_format(db_session: Session) -> None:
     db_session.commit()
     db_session.refresh(bot)
 
-    assert isinstance(bot.id, str)
     assert len(bot.id) == 32
     assert re.fullmatch(r"[a-z0-9]{32}", bot.id)
 
@@ -30,8 +29,6 @@ def test_bot_timestamps_create_and_update(db_session: Session) -> None:
     db_session.refresh(bot)
     after_create = datetime.now(timezone.utc).replace(tzinfo=None)
 
-    assert isinstance(bot.create_at, datetime)
-    assert isinstance(bot.last_update_at, datetime)
     # SQLite doesn't preserve timezone, so we verify timestamps are reasonable
     assert before_create <= bot.create_at <= after_create
     assert before_create <= bot.last_update_at <= after_create


### PR DESCRIPTION
## Summary
- Removed duplicated production-invariant tests in `tests/test_config.py` that were already covered in `TestDatabaseUrlConfig`.
- Kept unique invariant coverage for invalid proxy CIDRs and JWT signing key length checks.
- Removed type-tautology assertions in `tests/test_models.py` (`isinstance(...)`) where adjacent behavioral assertions already guarantee meaningful behavior.

## Rationale for removals/changes
- `tests/test_config.py` had repeated checks for the same invariants (memory rate limit in prod, admin-only write requirement, trust proxy CIDR requirement, JWT secret length, and non-prod bypass behavior). Keeping both sets increased maintenance cost without adding behavior coverage.
- The removed `isinstance` checks in `tests/test_models.py` were low-value because:
- `len(bot.id) == 32` and regex validation already enforce string-like ID behavior and format.
- timestamp range comparisons (`before <= ts <= after`) already validate usable datetime semantics and update behavior.

## Why remaining tests are valuable
- Config tests still verify required env, production/staging safety invariants, override paths, and normalization logic.
- Model tests still verify generated ID format, timestamp bounds, and `last_update_at` mutation on update.
- Unique edge-case coverage retained for invalid trusted proxy CIDRs and per-key JWT signing key length validation.

## Validation
- Ran: `uv run pytest -q tests/test_config.py tests/test_models.py`
- Note: full-suite run in this environment still has pre-existing async-plugin failures in `tests/test_tasks.py` (unrelated to this change).

Fixes #135