### PR TITLE
Add PostgreSQL statement timeout to engine config

### DIFF
--- a/src/jm_api/db/session.py
+++ b/src/jm_api/db/session.py
@@ -17,21 +17,35 @@ if TYPE_CHECKING:
 _SessionLocal: sessionmaker | None = None
 
 
+def _build_engine_kwargs(database_url: str) -> dict:
+    """Build SQLAlchemy engine kwargs with DB-specific connection options."""
+    is_sqlite = database_url.startswith("sqlite")
+    connect_args: dict[str, str | bool] = (
+        {"check_same_thread": False}
+        if is_sqlite
+        else {
+            # 30s timeout prevents runaway PostgreSQL queries from holding
+            # a pooled connection indefinitely.
+            "options": "-c statement_timeout=30000",
+        }
+    )
+    engine_kwargs: dict = {"connect_args": connect_args}
+    if not is_sqlite:
+        engine_kwargs.update(
+            pool_size=10,
+            max_overflow=20,
+            pool_pre_ping=True,
+            pool_recycle=300,
+        )
+    return engine_kwargs
+
+
 def _get_session_maker() -> sessionmaker:
     """Get or create the session maker."""
     global _SessionLocal
     if _SessionLocal is None:
         settings = get_settings()
-        is_sqlite = settings.database_url.startswith("sqlite")
-        connect_args = {"check_same_thread": False} if is_sqlite else {}
-        engine_kwargs: dict = {"connect_args": connect_args}
-        if not is_sqlite:
-            engine_kwargs.update(
-                pool_size=10,
-                max_overflow=20,
-                pool_pre_ping=True,
-                pool_recycle=300,
-            )
+        engine_kwargs = _build_engine_kwargs(settings.database_url)
         engine = create_engine(settings.database_url, **engine_kwargs)
         instrument_sqlalchemy(engine, settings)
         _SessionLocal = sessionmaker(
@@ -49,16 +63,7 @@ def init_db(app: FastAPI) -> None:
     Should be called during FastAPI lifespan startup.
     """
     settings = get_settings()
-    is_sqlite = settings.database_url.startswith("sqlite")
-    connect_args = {"check_same_thread": False} if is_sqlite else {}
-    engine_kwargs: dict = {"connect_args": connect_args}
-    if not is_sqlite:
-        engine_kwargs.update(
-            pool_size=10,
-            max_overflow=20,
-            pool_pre_ping=True,
-            pool_recycle=300,
-        )
+    engine_kwargs = _build_engine_kwargs(settings.database_url)
     engine = create_engine(settings.database_url, **engine_kwargs)
     instrument_sqlalchemy(engine, settings)
     session_factory = sessionmaker(

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -1,0 +1,17 @@
+from jm_api.db.session import _build_engine_kwargs
+
+
+def test_build_engine_kwargs_for_postgres_sets_statement_timeout() -> None:
+    kwargs = _build_engine_kwargs("postgresql://user:pass@localhost/db")
+
+    assert kwargs["connect_args"] == {"options": "-c statement_timeout=30000"}
+    assert kwargs["pool_size"] == 10
+    assert kwargs["max_overflow"] == 20
+    assert kwargs["pool_pre_ping"] is True
+    assert kwargs["pool_recycle"] == 300
+
+
+def test_build_engine_kwargs_for_sqlite_sets_check_same_thread_only() -> None:
+    kwargs = _build_engine_kwargs("sqlite:///:memory:")
+
+    assert kwargs == {"connect_args": {"check_same_thread": False}}


### PR DESCRIPTION
## Summary
- add PostgreSQL `statement_timeout` to SQLAlchemy `connect_args` (`30s`)
- refactor engine kwarg construction into `_build_engine_kwargs` to keep startup/session paths consistent
- add tests for PostgreSQL and SQLite engine kwargs

## Testing
- `uv run pytest -q tests/test_db_session.py tests/test_config.py`

Fixes #137