### PR TITLE
Standardize 500 error handling with global middleware

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -52,18 +52,18 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	accessToken, expiresIn, err := h.authService.CreateAccessToken(user.ID, service.WithUserClaims(user.Email, user.IsAdmin))
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create token"})
+		writeInternalError(w, r, "create access token", err)
 		return
 	}
 
 	refreshToken, jti, expiresAt, err := h.authService.CreateRefreshToken(user.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create refresh token"})
+		writeInternalError(w, r, "create refresh token", err)
 		return
 	}
 
 	if err := h.authService.PersistRefreshToken(r.Context(), jti, user.ID, expiresAt, r.UserAgent(), r.RemoteAddr); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to persist session"})
+		writeInternalError(w, r, "persist refresh token", err)
 		return
 	}
 
@@ -126,7 +126,7 @@ func (h *AuthHandler) Signup(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusConflict, map[string]string{"error": "email already registered"})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create user"})
+		writeInternalError(w, r, "signup user", err)
 		return
 	}
 
@@ -170,7 +170,7 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	// Check for replay
 	replayed, err := h.authService.DetectReplay(r.Context(), jti, userID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "session error"})
+		writeInternalError(w, r, "detect refresh token replay", err)
 		return
 	}
 	if replayed {
@@ -190,20 +190,20 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	// Rotate
 	newRefreshToken, _, refreshExpiry, err := h.authService.RotateRefreshToken(r.Context(), jti, userID, r.UserAgent(), r.RemoteAddr)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to rotate token"})
+		writeInternalError(w, r, "rotate refresh token", err)
 		return
 	}
 
 	// Load user to embed claims in access token
 	user, err := h.authService.GetUserByID(r.Context(), userID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "user not found"})
+		writeInternalError(w, r, "load user during refresh", err)
 		return
 	}
 
 	accessToken, expiresIn, err := h.authService.CreateAccessToken(userID, service.WithUserClaims(user.Email, user.IsAdmin))
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create token"})
+		writeInternalError(w, r, "create access token", err)
 		return
 	}
 
@@ -281,7 +281,7 @@ func (h *AuthHandler) Sessions(w http.ResponseWriter, r *http.Request) {
 
 	sessions, err := h.authService.ListUserSessions(r.Context(), authUser.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list sessions"})
+		writeInternalError(w, r, "list user sessions", err)
 		return
 	}
 
@@ -332,7 +332,7 @@ func (h *AuthHandler) RevokeSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.authService.RevokeSession(r.Context(), jti); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to revoke session"})
+		writeInternalError(w, r, "revoke session", err)
 		return
 	}
 
@@ -356,7 +356,7 @@ func (h *AuthHandler) RevokeOtherSessions(w http.ResponseWriter, r *http.Request
 
 	revoked, err := h.authService.RevokeOtherSessions(r.Context(), authUser.ID, currentJTI)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to revoke sessions"})
+		writeInternalError(w, r, "revoke other sessions", err)
 		return
 	}
 

--- a/internal/handler/bots.go
+++ b/internal/handler/bots.go
@@ -110,13 +110,13 @@ func (h *BotHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	bots, err := h.queries.ListBots(r.Context(), params)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list bots"})
+		writeInternalError(w, r, "list bots", err)
 		return
 	}
 
 	total, err := h.queries.CountBots(r.Context(), countParams)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to count bots"})
+		writeInternalError(w, r, "count bots", err)
 		return
 	}
 
@@ -170,7 +170,7 @@ func (h *BotHandler) Create(w http.ResponseWriter, r *http.Request) {
 		LastRunLog: lastRunLog,
 	})
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create bot"})
+		writeInternalError(w, r, "create bot", err)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (h *BotHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	bot, err := h.queries.UpdateBot(r.Context(), updateParams)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update bot"})
+		writeInternalError(w, r, "update bot", err)
 		return
 	}
 
@@ -231,7 +231,7 @@ func (h *BotHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.queries.DeleteBot(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete bot"})
+		writeInternalError(w, r, "delete bot", err)
 		return
 	}
 

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/jack/jm-api-go/internal/middleware"
+)
+
+func writeInternalError(w http.ResponseWriter, r *http.Request, operation string, err error) {
+	slog.Error("request failed",
+		"request_id", middleware.GetRequestID(r.Context()),
+		"method", r.Method,
+		"path", r.URL.Path,
+		"operation", operation,
+		"error", err,
+	)
+	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Internal Server Error"})
+}

--- a/internal/handler/tasks.go
+++ b/internal/handler/tasks.go
@@ -40,7 +40,7 @@ func (h *TaskHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Payload: req.Payload,
 	})
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create task"})
+		writeInternalError(w, r, "create task", err)
 		return
 	}
 

--- a/internal/handler/webhooks.go
+++ b/internal/handler/webhooks.go
@@ -85,7 +85,7 @@ func (h *WebhookHandler) Create(w http.ResponseWriter, r *http.Request) {
 		IsActive:   true,
 	})
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create webhook"})
+		writeInternalError(w, r, "create webhook", err)
 		return
 	}
 
@@ -101,7 +101,7 @@ func (h *WebhookHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	webhooks, err := h.queries.ListWebhooksByUserID(r.Context(), user.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list webhooks"})
+		writeInternalError(w, r, "list webhooks", err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (h *WebhookHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	webhook, err := h.queries.UpdateWebhook(r.Context(), params)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update webhook"})
+		writeInternalError(w, r, "update webhook", err)
 		return
 	}
 
@@ -198,7 +198,7 @@ func (h *WebhookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.queries.DeleteWebhook(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete webhook"})
+		writeInternalError(w, r, "delete webhook", err)
 		return
 	}
 
@@ -221,7 +221,7 @@ func (h *WebhookHandler) Deliveries(w http.ResponseWriter, r *http.Request) {
 
 	logs, err := h.queries.ListDeliveryLogsByWebhookID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list deliveries"})
+		writeInternalError(w, r, "list webhook deliveries", err)
 		return
 	}
 

--- a/internal/middleware/errorhandler.go
+++ b/internal/middleware/errorhandler.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// ErrorHandler catches unhandled panics and returns a standardized JSON error.
+func ErrorHandler() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					slog.Error("unhandled panic in request",
+						"request_id", GetRequestID(r.Context()),
+						"method", r.Method,
+						"path", r.URL.Path,
+						"error", rec,
+					)
+
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusInternalServerError)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "Internal Server Error"})
+				}
+			}()
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/errorhandler_test.go
+++ b/internal/middleware/errorhandler_test.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorHandler_RecoversPanicAndReturnsStandard500(t *testing.T) {
+	h := ErrorHandler()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("db connection failed")
+	}))
+
+	req := httptest.NewRequest("GET", "/panic", nil)
+	req = req.WithContext(context.WithValue(req.Context(), RequestIDKey, "req-123"))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var body map[string]string
+	err := json.Unmarshal(rr.Body.Bytes(), &body)
+	assert.NoError(t, err)
+	assert.Equal(t, "Internal Server Error", body["error"])
+}
+
+func TestErrorHandler_LogsStructuredError(t *testing.T) {
+	var buf bytes.Buffer
+	orig := slog.Default()
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	slog.SetDefault(logger)
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	h := ErrorHandler()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+
+	req := httptest.NewRequest("POST", "/v1/tasks", nil)
+	req = req.WithContext(context.WithValue(req.Context(), RequestIDKey, "req-456"))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	logLine := buf.String()
+	assert.Contains(t, logLine, "unhandled panic in request")
+	assert.Contains(t, logLine, "\"request_id\":\"req-456\"")
+	assert.Contains(t, logLine, "\"method\":\"POST\"")
+	assert.Contains(t, logLine, "\"path\":\"/v1/tasks\"")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,6 +152,7 @@ func (s *Server) setupRoutes() {
 		r.Use(middleware.TrustedHost(cfg.AllowedHosts))
 	}
 	r.Use(middleware.RequestID(cfg.RequestIDHeader))
+	r.Use(middleware.ErrorHandler())
 	r.Use(middleware.SecurityHeaders(cfg))
 	r.Use(s.shutdownGuard.Middleware)
 	r.Use(middleware.BodyLimit(1 << 20)) // 1MB


### PR DESCRIPTION
## Summary
- add a global HTTP error middleware that recovers unhandled panics
- return a consistent JSON 500 response body: 
- log panic and handler failures with structured fields (request_id, method, path, operation, error)
- route existing handler-level 500 paths through a shared internal-error helper
- add middleware tests for panic recovery and structured logging

## Verification
- ?   	github.com/jack/jm-api-go/cmd/api	[no test files]
?   	github.com/jack/jm-api-go/cmd/worker	[no test files]
ok  	github.com/jack/jm-api-go/internal/config	(cached)
?   	github.com/jack/jm-api-go/internal/db/sqlc	[no test files]
ok  	github.com/jack/jm-api-go/internal/handler	(cached)
ok  	github.com/jack/jm-api-go/internal/middleware	(cached)
ok  	github.com/jack/jm-api-go/internal/model	(cached)
ok  	github.com/jack/jm-api-go/internal/observability	(cached)
?   	github.com/jack/jm-api-go/internal/server	[no test files]
ok  	github.com/jack/jm-api-go/internal/service	(cached)
?   	github.com/jack/jm-api-go/static	[no test files]

Closes #145