### PR TITLE
Add concurrent rate-limit, Redis chaos, and integration test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
           mkdir -p test-results
           go test ./... -count=1 -race -v -tags integration 2>&1 | tee test-results/test-output.txt
 
+      - name: Run chaos tests (optional)
+        continue-on-error: true
+        run: |
+          mkdir -p test-results
+          go test ./internal/integration -count=1 -v -tags integration -run "RedisUnavailable|GracefulDegradation" 2>&1 | tee test-results/chaos-test-output.txt
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/internal/integration/rate_limit_integration_test.go
+++ b/internal/integration/rate_limit_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jack/jm-api-go/internal/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimit_RequestLifecycle(t *testing.T) {
+	r := chi.NewRouter()
+	rl := middleware.NewRateLimiter(nil, middleware.RateLimitConfig{PerMinute: 2, Window: 200 * time.Millisecond})
+	r.Use(rl.Middleware)
+	r.Get("/v1/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+		req.RemoteAddr = "10.10.10.10:4321"
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "2", rr.Header().Get("X-RateLimit-Limit"))
+		assert.NotEmpty(t, rr.Header().Get("X-RateLimit-Remaining"))
+		assert.NotEmpty(t, rr.Header().Get("X-RateLimit-Reset"))
+	}
+
+	blockedReq := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	blockedReq.RemoteAddr = "10.10.10.10:4321"
+	blockedRR := httptest.NewRecorder()
+	r.ServeHTTP(blockedRR, blockedReq)
+
+	assert.Equal(t, http.StatusTooManyRequests, blockedRR.Code)
+	assert.NotEmpty(t, blockedRR.Header().Get("Retry-After"))
+
+	time.Sleep(250 * time.Millisecond)
+
+	refillReq := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	refillReq.RemoteAddr = "10.10.10.10:4321"
+	refillRR := httptest.NewRecorder()
+	r.ServeHTTP(refillRR, refillReq)
+
+	assert.Equal(t, http.StatusOK, refillRR.Code)
+}

--- a/internal/integration/redis_chaos_integration_test.go
+++ b/internal/integration/redis_chaos_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jack/jm-api-go/internal/middleware"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimiter_GracefulDegradation_WhenRedisUnavailable(t *testing.T) {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:         "127.0.0.1:0",
+		DialTimeout:  5 * time.Millisecond,
+		ReadTimeout:  5 * time.Millisecond,
+		WriteTimeout: 5 * time.Millisecond,
+		MaxRetries:   0,
+	})
+	t.Cleanup(func() { _ = redisClient.Close() })
+
+	r := chi.NewRouter()
+	rl := middleware.NewRateLimiter(redisClient, middleware.RateLimitConfig{PerMinute: 1})
+	r.Use(rl.Middleware)
+	r.Get("/v1/dependency-check", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/dependency-check", nil)
+		req.RemoteAddr = "11.11.11.11:5555"
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "1", rr.Header().Get("X-RateLimit-Limit"))
+		assert.NotEmpty(t, rr.Header().Get("X-RateLimit-Remaining"))
+	}
+}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -3,8 +3,12 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,4 +79,97 @@ func TestRateLimiter_OverrideConfig(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+}
+
+func TestRateLimiter_ConcurrentBurst_EnforcesLimit(t *testing.T) {
+	rl := NewRateLimiter(nil, RateLimitConfig{PerMinute: 10})
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var allowed int32
+	var throttled int32
+
+	const totalRequests = 50
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < totalRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			req := httptest.NewRequest("GET", "/v1/resource", nil)
+			req.RemoteAddr = "9.9.9.9:1234"
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			switch rr.Code {
+			case http.StatusOK:
+				atomic.AddInt32(&allowed, 1)
+			case http.StatusTooManyRequests:
+				atomic.AddInt32(&throttled, 1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	assert.Equal(t, int32(10), allowed)
+	assert.Equal(t, int32(totalRequests)-allowed, throttled)
+}
+
+func TestRateLimiter_WindowRefill_AllowsAfterReset(t *testing.T) {
+	rl := NewRateLimiter(nil, RateLimitConfig{PerMinute: 2, Window: 200 * time.Millisecond})
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = "7.7.7.7:1234"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	blockedReq := httptest.NewRequest("GET", "/", nil)
+	blockedReq.RemoteAddr = "7.7.7.7:1234"
+	blockedRR := httptest.NewRecorder()
+	handler.ServeHTTP(blockedRR, blockedReq)
+	assert.Equal(t, http.StatusTooManyRequests, blockedRR.Code)
+
+	time.Sleep(250 * time.Millisecond)
+
+	refillReq := httptest.NewRequest("GET", "/", nil)
+	refillReq.RemoteAddr = "7.7.7.7:1234"
+	refillRR := httptest.NewRecorder()
+	handler.ServeHTTP(refillRR, refillReq)
+	assert.Equal(t, http.StatusOK, refillRR.Code)
+}
+
+func TestRateLimiter_RedisUnavailable_FailsOpen(t *testing.T) {
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:         "127.0.0.1:0",
+		DialTimeout:  5 * time.Millisecond,
+		ReadTimeout:  5 * time.Millisecond,
+		WriteTimeout: 5 * time.Millisecond,
+		MaxRetries:   0,
+	})
+	t.Cleanup(func() { _ = redisClient.Close() })
+
+	rl := NewRateLimiter(redisClient, RateLimitConfig{PerMinute: 1})
+	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.RemoteAddr = "8.8.8.8:1234"
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	}
 }


### PR DESCRIPTION
## Summary
- add concurrent burst coverage for rate limiting to verify throttling under parallel load
- add boundary/refill coverage for short windows to validate reset behavior
- add fail-open chaos coverage when Redis is unavailable
- expand integration suite with dedicated domain tests under internal/integration
- update CI to run chaos tests as optional fail-soft checks

## Validation
- /usr/local/go/bin/go test ./... -count=1
- /usr/local/go/bin/go test ./... -count=1 -tags integration -v

Closes #148