### PR TITLE
Make DB pool settings configurable via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Required
 JM_API_DATABASE_URL=postgresql://jm_api:jm_api@localhost:5432/jm_api
 
+# Database pool sizing (defaults: max=20, min=2)
+# Small (dev/test): max=10, min=2
+# Medium (production): max=20, min=5
+# Large (high-load): max=50, min=10
+JM_API_DB_POOL_MAX_CONNS=20
+JM_API_DB_POOL_MIN_CONNS=2
+
 # Environment
 JM_API_ENVIRONMENT=development
 JM_API_DEBUG=true

--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ All configuration is via environment variables with the `JM_API_` prefix. Unset 
 | `JM_API_APP_NAME` | `jm-api` | Application name (used in metrics labels) |
 | `JM_API_APP_VERSION` | `0.1.0` | Application version |
 
+### Database Pool
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `JM_API_DB_POOL_MAX_CONNS` | `20` | Maximum PostgreSQL connections in pool |
+| `JM_API_DB_POOL_MIN_CONNS` | `2` | Minimum PostgreSQL connections maintained in pool |
+| `DB_POOL_MAX_CONNS` | `20` | Legacy alias for `JM_API_DB_POOL_MAX_CONNS` |
+| `DB_POOL_MIN_CONNS` | `2` | Legacy alias for `JM_API_DB_POOL_MIN_CONNS` |
+
+Recommended sizing:
+- Small (dev/test): max=10, min=2
+- Medium (production): max=20, min=5
+- Large (high-load): max=50, min=10
+
 ### Server
 
 | Variable | Default | Description |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,26 +10,28 @@ import (
 )
 
 type Config struct {
-	AppName    string
-	AppVersion string
+	AppName     string
+	AppVersion  string
 	Environment string
 	Debug       bool
 
 	DatabaseURL             string
 	DBMigrationCheckEnabled bool
 	DBExpectedMigration     int
+	DBPoolMaxConns          int
+	DBPoolMinConns          int
 
 	APIV1Prefix string
 
 	// Request/Security
-	RequestIDHeader                    string
-	SecurityHeadersEnabled             bool
-	SecurityHeaderXContentTypeOptions  string
-	SecurityHeaderXFrameOptions        string
-	SecurityHeaderHSTSMaxAge           int
+	RequestIDHeader                     string
+	SecurityHeadersEnabled              bool
+	SecurityHeaderXContentTypeOptions   string
+	SecurityHeaderXFrameOptions         string
+	SecurityHeaderHSTSMaxAge            int
 	SecurityHeaderHSTSIncludeSubdomains bool
-	SecurityHeaderHSTSPreload          bool
-	SecurityHeaderAdminCSP             string
+	SecurityHeaderHSTSPreload           bool
+	SecurityHeaderAdminCSP              string
 
 	// CORS
 	AllowOrigins         []string
@@ -43,9 +45,9 @@ type Config struct {
 	TrustedProxyCIDRs []*net.IPNet
 
 	// Logging
-	LogLevel          string
-	LogJSON           bool
-	LogSampleRate     float64
+	LogLevel             string
+	LogJSON              bool
+	LogSampleRate        float64
 	SlowQueryThresholdMS int
 
 	// Tracing
@@ -80,15 +82,15 @@ type Config struct {
 	RateLimitAPIPerMinute int
 
 	// Redis
-	RedisURL              string
-	RedisPort             int
-	RedisPassword         string
-	RedisDB               int
-	RedisConnPoolSize     int
-	RedisConnPoolMax      int
-	RedisSocketTimeout    int
-	RedisConnectTimeout   int
-	RedisRetryOnTimeout   bool
+	RedisURL                 string
+	RedisPort                int
+	RedisPassword            string
+	RedisDB                  int
+	RedisConnPoolSize        int
+	RedisConnPoolMax         int
+	RedisSocketTimeout       int
+	RedisConnectTimeout      int
+	RedisRetryOnTimeout      bool
 	RedisHealthCheckInterval int
 
 	// Server
@@ -101,25 +103,27 @@ type Config struct {
 
 func Load() (*Config, error) {
 	c := &Config{
-		AppName:    envOrDefault("JM_API_APP_NAME", "jm-api"),
-		AppVersion: envOrDefault("JM_API_APP_VERSION", "0.1.0"),
+		AppName:     envOrDefault("JM_API_APP_NAME", "jm-api"),
+		AppVersion:  envOrDefault("JM_API_APP_VERSION", "0.1.0"),
 		Environment: envOrDefault("JM_API_ENVIRONMENT", "development"),
 		Debug:       envBool("JM_API_DEBUG", false),
 
 		DatabaseURL:             os.Getenv("JM_API_DATABASE_URL"),
 		DBMigrationCheckEnabled: envBool("JM_API_DB_MIGRATION_CHECK_ENABLED", true),
 		DBExpectedMigration:     envInt("JM_API_DB_EXPECTED_MIGRATION", 1),
+		DBPoolMaxConns:          envIntFromKeys([]string{"JM_API_DB_POOL_MAX_CONNS", "DB_POOL_MAX_CONNS"}, 20),
+		DBPoolMinConns:          envIntFromKeys([]string{"JM_API_DB_POOL_MIN_CONNS", "DB_POOL_MIN_CONNS"}, 2),
 
 		APIV1Prefix: envOrDefault("JM_API_API_V1_PREFIX", "/api/v1"),
 
-		RequestIDHeader:                    envOrDefault("JM_API_REQUEST_ID_HEADER", "X-Request-ID"),
-		SecurityHeadersEnabled:             envBool("JM_API_SECURITY_HEADERS_ENABLED", true),
-		SecurityHeaderXContentTypeOptions:  envOrDefault("JM_API_SECURITY_HEADER_X_CONTENT_TYPE_OPTIONS", "nosniff"),
-		SecurityHeaderXFrameOptions:        envOrDefault("JM_API_SECURITY_HEADER_X_FRAME_OPTIONS", "DENY"),
-		SecurityHeaderHSTSMaxAge:           envInt("JM_API_SECURITY_HEADER_HSTS_MAX_AGE", 31536000),
+		RequestIDHeader:                     envOrDefault("JM_API_REQUEST_ID_HEADER", "X-Request-ID"),
+		SecurityHeadersEnabled:              envBool("JM_API_SECURITY_HEADERS_ENABLED", true),
+		SecurityHeaderXContentTypeOptions:   envOrDefault("JM_API_SECURITY_HEADER_X_CONTENT_TYPE_OPTIONS", "nosniff"),
+		SecurityHeaderXFrameOptions:         envOrDefault("JM_API_SECURITY_HEADER_X_FRAME_OPTIONS", "DENY"),
+		SecurityHeaderHSTSMaxAge:            envInt("JM_API_SECURITY_HEADER_HSTS_MAX_AGE", 31536000),
 		SecurityHeaderHSTSIncludeSubdomains: envBool("JM_API_SECURITY_HEADER_HSTS_INCLUDE_SUBDOMAINS", true),
-		SecurityHeaderHSTSPreload:          envBool("JM_API_SECURITY_HEADER_HSTS_PRELOAD", false),
-		SecurityHeaderAdminCSP:             envOrDefault("JM_API_SECURITY_HEADER_ADMIN_CSP", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; frame-ancestors 'none'"),
+		SecurityHeaderHSTSPreload:           envBool("JM_API_SECURITY_HEADER_HSTS_PRELOAD", false),
+		SecurityHeaderAdminCSP:              envOrDefault("JM_API_SECURITY_HEADER_ADMIN_CSP", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; frame-ancestors 'none'"),
 
 		AllowOrigins:         envSlice("JM_API_ALLOW_ORIGINS", nil),
 		CORSAllowCredentials: envBool("JM_API_CORS_ALLOW_CREDENTIALS", true),
@@ -129,9 +133,9 @@ func Load() (*Config, error) {
 		AllowedHosts:      envSlice("JM_API_ALLOWED_HOSTS", nil),
 		TrustProxyHeaders: envBool("JM_API_TRUST_PROXY_HEADERS", false),
 
-		LogLevel:          strings.ToUpper(envOrDefault("JM_API_LOG_LEVEL", "INFO")),
-		LogJSON:           envBool("JM_API_LOG_JSON", true),
-		LogSampleRate:     envFloat("JM_API_LOG_SAMPLE_RATE", 1.0),
+		LogLevel:             strings.ToUpper(envOrDefault("JM_API_LOG_LEVEL", "INFO")),
+		LogJSON:              envBool("JM_API_LOG_JSON", true),
+		LogSampleRate:        envFloat("JM_API_LOG_SAMPLE_RATE", 1.0),
 		SlowQueryThresholdMS: envInt("JM_API_SLOW_QUERY_THRESHOLD_MS", 500),
 
 		TracingEnabled:        envBool("JM_API_TRACING_ENABLED", false),
@@ -158,15 +162,15 @@ func Load() (*Config, error) {
 		RateLimitStorageURI:   envOrDefault("JM_API_RATE_LIMIT_STORAGE_URI", "memory://"),
 		RateLimitAPIPerMinute: envInt("JM_API_RATE_LIMIT_API_PER_MINUTE", 120),
 
-		RedisURL:              os.Getenv("JM_API_REDIS_URL"),
-		RedisPort:             envInt("JM_API_REDIS_PORT", 6379),
-		RedisPassword:         os.Getenv("JM_API_REDIS_PASSWORD"),
-		RedisDB:               envInt("JM_API_REDIS_DB", 0),
-		RedisConnPoolSize:     envInt("JM_API_REDIS_CONNECTION_POOL_SIZE", 10),
-		RedisConnPoolMax:      envInt("JM_API_REDIS_CONNECTION_POOL_MAX", 20),
-		RedisSocketTimeout:    envInt("JM_API_REDIS_SOCKET_TIMEOUT", 5),
-		RedisConnectTimeout:   envInt("JM_API_REDIS_SOCKET_CONNECT_TIMEOUT", 5),
-		RedisRetryOnTimeout:   envBool("JM_API_REDIS_RETRY_ON_TIMEOUT", true),
+		RedisURL:                 os.Getenv("JM_API_REDIS_URL"),
+		RedisPort:                envInt("JM_API_REDIS_PORT", 6379),
+		RedisPassword:            os.Getenv("JM_API_REDIS_PASSWORD"),
+		RedisDB:                  envInt("JM_API_REDIS_DB", 0),
+		RedisConnPoolSize:        envInt("JM_API_REDIS_CONNECTION_POOL_SIZE", 10),
+		RedisConnPoolMax:         envInt("JM_API_REDIS_CONNECTION_POOL_MAX", 20),
+		RedisSocketTimeout:       envInt("JM_API_REDIS_SOCKET_TIMEOUT", 5),
+		RedisConnectTimeout:      envInt("JM_API_REDIS_SOCKET_CONNECT_TIMEOUT", 5),
+		RedisRetryOnTimeout:      envBool("JM_API_REDIS_RETRY_ON_TIMEOUT", true),
 		RedisHealthCheckInterval: envInt("JM_API_REDIS_HEALTH_CHECK_INTERVAL", 30),
 
 		ServerPort: envInt("JM_API_SERVER_PORT", envInt("PORT", 8000)),
@@ -208,6 +212,16 @@ func (c *Config) validate() error {
 
 	if c.LogSampleRate <= 0 || c.LogSampleRate > 1 {
 		return fmt.Errorf("JM_API_LOG_SAMPLE_RATE must be > 0 and <= 1")
+	}
+
+	if c.DBPoolMaxConns <= 0 {
+		return fmt.Errorf("DB pool max connections must be > 0")
+	}
+	if c.DBPoolMinConns < 0 {
+		return fmt.Errorf("DB pool min connections must be >= 0")
+	}
+	if c.DBPoolMinConns > c.DBPoolMaxConns {
+		return fmt.Errorf("DB pool min connections (%d) cannot exceed max (%d)", c.DBPoolMinConns, c.DBPoolMaxConns)
 	}
 
 	isProd := c.Environment == "production" || c.Environment == "staging"
@@ -265,6 +279,19 @@ func envInt(key string, defaultVal int) int {
 		return defaultVal
 	}
 	return i
+}
+
+func envIntFromKeys(keys []string, defaultVal int) int {
+	for _, key := range keys {
+		if v := os.Getenv(key); v != "" {
+			i, err := strconv.Atoi(v)
+			if err != nil {
+				return defaultVal
+			}
+			return i
+		}
+	}
+	return defaultVal
 }
 
 func envFloat(key string, defaultVal float64) float64 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,8 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, 15, cfg.JWTAccessTokenExpireMin)
 	assert.Equal(t, 7, cfg.JWTRefreshTokenExpireDays)
 	assert.Equal(t, 120, cfg.RateLimitAPIPerMinute)
+	assert.Equal(t, 20, cfg.DBPoolMaxConns)
+	assert.Equal(t, 2, cfg.DBPoolMinConns)
 	assert.Equal(t, 8000, cfg.ServerPort)
 }
 
@@ -141,6 +143,8 @@ func TestLoad_CustomValues(t *testing.T) {
 	setEnv(t, "JM_API_SERVER_PORT", "9000")
 	setEnv(t, "JM_API_DEBUG", "true")
 	setEnv(t, "JM_API_ALLOW_ORIGINS", "http://localhost:3000,http://example.com")
+	setEnv(t, "JM_API_DB_POOL_MAX_CONNS", "50")
+	setEnv(t, "JM_API_DB_POOL_MIN_CONNS", "10")
 
 	cfg, err := Load()
 	require.NoError(t, err)
@@ -148,6 +152,29 @@ func TestLoad_CustomValues(t *testing.T) {
 	assert.Equal(t, 9000, cfg.ServerPort)
 	assert.True(t, cfg.Debug)
 	assert.Equal(t, []string{"http://localhost:3000", "http://example.com"}, cfg.AllowOrigins)
+	assert.Equal(t, 50, cfg.DBPoolMaxConns)
+	assert.Equal(t, 10, cfg.DBPoolMinConns)
+}
+
+func TestLoad_DBPoolLegacyEnvKeys(t *testing.T) {
+	setEnv(t, "JM_API_DATABASE_URL", "postgres://localhost/test")
+	setEnv(t, "DB_POOL_MAX_CONNS", "40")
+	setEnv(t, "DB_POOL_MIN_CONNS", "8")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, 40, cfg.DBPoolMaxConns)
+	assert.Equal(t, 8, cfg.DBPoolMinConns)
+}
+
+func TestLoad_DBPoolValidation_MinExceedsMax(t *testing.T) {
+	setEnv(t, "JM_API_DATABASE_URL", "postgres://localhost/test")
+	setEnv(t, "JM_API_DB_POOL_MAX_CONNS", "5")
+	setEnv(t, "JM_API_DB_POOL_MIN_CONNS", "10")
+
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot exceed max")
 }
 
 func TestIsProd(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,7 +46,7 @@ func New(cfg *config.Config) (*Server, error) {
 	observability.SetupLogging(cfg.LogLevel, cfg.LogJSON, cfg.LogSampleRate)
 
 	// Setup database
-	if err := s.setupDB(cfg.DatabaseURL); err != nil {
+	if err := s.setupDB(cfg); err != nil {
 		return nil, fmt.Errorf("setting up database: %w", err)
 	}
 
@@ -75,13 +75,13 @@ func New(cfg *config.Config) (*Server, error) {
 	return s, nil
 }
 
-func (s *Server) setupDB(databaseURL string) error {
-	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+func (s *Server) setupDB(cfg *config.Config) error {
+	poolConfig, err := pgxpool.ParseConfig(cfg.DatabaseURL)
 	if err != nil {
 		return fmt.Errorf("parsing database URL: %w", err)
 	}
-	poolConfig.MaxConns = 20
-	poolConfig.MinConns = 2
+	poolConfig.MaxConns = int32(cfg.DBPoolMaxConns)
+	poolConfig.MinConns = int32(cfg.DBPoolMinConns)
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
 	if err != nil {
@@ -93,7 +93,7 @@ func (s *Server) setupDB(databaseURL string) error {
 	}
 
 	s.db = pool
-	slog.Info("database connected")
+	slog.Info("database connected", "db_pool_max_conns", cfg.DBPoolMaxConns, "db_pool_min_conns", cfg.DBPoolMinConns)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- make PostgreSQL connection pool sizing configurable with env vars instead of hardcoded values
- add startup validation for invalid pool configuration (including min > max)
- log configured DB pool max/min on successful startup
- document new configuration in README and .env.example with sizing guidance

## Changes
- Added DBPoolMaxConns and DBPoolMinConns to app config
- Read values from JM_API_DB_POOL_MAX_CONNS / JM_API_DB_POOL_MIN_CONNS
- Added compatibility aliases: DB_POOL_MAX_CONNS / DB_POOL_MIN_CONNS
- Updated server DB setup to apply configured pool values
- Added config tests for defaults, custom values, legacy aliases, and min>max validation

## Verification
- /usr/local/go/bin/go test ./...

Closes #150