### PR TITLE
Remove dead SQLite config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,6 @@ The server enforces these additional validations when `JM_API_ENVIRONMENT` is `p
 - `JM_API_RATE_LIMIT_STORAGE_URI` must not be `memory://` (Redis required)
 - `JM_API_BOTS_WRITE_ADMIN_ONLY=true` or `JM_API_I_UNDERSTAND_RISK=true`
 - If `JM_API_TRUST_PROXY_HEADERS=true`, `JM_API_TRUSTED_PROXY_CIDRS` must be set
-- SQLite is not allowed (PostgreSQL only)
 
 ## CI/CD Pipeline
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,9 +212,6 @@ func (c *Config) validate() error {
 
 	isProd := c.Environment == "production" || c.Environment == "staging"
 	if isProd {
-		if strings.Contains(c.DatabaseURL, "sqlite") {
-			return fmt.Errorf("SQLite not allowed in %s; use PostgreSQL", c.Environment)
-		}
 		if len(c.JWTSecretKey) < 32 {
 			return fmt.Errorf("JWT secret key must be >= 32 bytes in %s", c.Environment)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,16 +40,15 @@ func TestLoad_MissingDatabaseURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "JM_API_DATABASE_URL is required")
 }
 
-func TestLoad_ProductionValidation_SQLite(t *testing.T) {
-	setEnv(t, "JM_API_DATABASE_URL", "sqlite:///test.db")
+func TestLoad_ProductionValidation_DoesNotValidateDatabaseScheme(t *testing.T) {
+	setEnv(t, "JM_API_DATABASE_URL", "mysql://localhost/test")
 	setEnv(t, "JM_API_ENVIRONMENT", "production")
 	setEnv(t, "JM_API_JWT_SECRET_KEY", "this-is-a-very-long-secret-key-for-production-use")
 	setEnv(t, "JM_API_RATE_LIMIT_STORAGE_URI", "redis://localhost")
 	setEnv(t, "JM_API_BOTS_WRITE_ADMIN_ONLY", "true")
 
 	_, err := Load()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "SQLite not allowed")
+	require.NoError(t, err)
 }
 
 func TestLoad_ProductionValidation_WeakJWT(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove the production/staging SQLite-specific validation from config loading
- keep existing production safeguards (JWT length, Redis rate limit storage, bot write controls, trusted proxy CIDRs)
- update config tests to reflect that database URL scheme is not validated at config layer
- remove outdated SQLite note from README production requirements

## Verification
- /usr/local/go/bin/go test ./...

Closes #157