### PR TITLE
Make webhook delivery asynchronous via task queue

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -40,11 +40,13 @@ func run() error {
 
 	queries := sqlc.New(pool)
 	worker := service.NewWorkerService(queries)
+	webhookSvc := service.NewWebhookService(queries)
 
 	// Register task handlers
 	worker.RegisterHandler("echo", func(ctx context.Context, payload json.RawMessage) (json.RawMessage, error) {
 		return payload, nil
 	})
+	worker.RegisterHandler(service.WebhookDeliveryTaskType, webhookSvc.HandleWebhookDeliveryTask)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()

--- a/internal/service/webhook.go
+++ b/internal/service/webhook.go
@@ -17,10 +17,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jack/jm-api-go/internal/db/sqlc"
 	"github.com/jack/jm-api-go/internal/model"
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const WebhookDeliveryTaskType = "webhook.delivery"
+
+type WebhookDeliveryTaskPayload struct {
+	WebhookID string          `json:"webhook_id"`
+	EventType string          `json:"event_type"`
+	Data      json.RawMessage `json:"data"`
+}
 
 type WebhookService struct {
 	queries *sqlc.Queries
@@ -248,10 +256,79 @@ func (ws *WebhookService) DispatchEvent(ctx context.Context, eventType string, d
 	}
 
 	for _, webhook := range webhooks {
-		go func(wh sqlc.Webhook) {
-			if err := ws.DeliverEvent(context.Background(), wh, eventType, data); err != nil {
-				slog.Error("webhook delivery failed", "webhook_id", wh.ID, "error", err)
-			}
-		}(webhook)
+		if err := ws.EnqueueDeliveryTask(ctx, webhook.ID, eventType, data); err != nil {
+			slog.Error("failed to enqueue webhook delivery", "webhook_id", webhook.ID, "event_type", eventType, "error", err)
+		}
 	}
+}
+
+func (ws *WebhookService) EnqueueDeliveryTask(ctx context.Context, webhookID, eventType string, data interface{}) error {
+	payload, err := marshalWebhookDeliveryTaskPayload(webhookID, eventType, data)
+	if err != nil {
+		return err
+	}
+
+	_, err = ws.queries.CreateTask(ctx, sqlc.CreateTaskParams{
+		ID:      model.GenerateID(),
+		Type:    WebhookDeliveryTaskType,
+		Payload: payload,
+	})
+	if err != nil {
+		return fmt.Errorf("creating webhook task: %w", err)
+	}
+
+	return nil
+}
+
+func marshalWebhookDeliveryTaskPayload(webhookID, eventType string, data interface{}) (json.RawMessage, error) {
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal webhook task data: %w", err)
+	}
+
+	payload, err := json.Marshal(WebhookDeliveryTaskPayload{
+		WebhookID: webhookID,
+		EventType: eventType,
+		Data:      dataJSON,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal webhook task payload: %w", err)
+	}
+
+	return payload, nil
+}
+
+func (ws *WebhookService) HandleWebhookDeliveryTask(ctx context.Context, payload json.RawMessage) (json.RawMessage, error) {
+	var taskPayload WebhookDeliveryTaskPayload
+	if err := json.Unmarshal(payload, &taskPayload); err != nil {
+		return nil, fmt.Errorf("unmarshal webhook task payload: %w", err)
+	}
+
+	if taskPayload.WebhookID == "" {
+		return nil, fmt.Errorf("webhook_id is required")
+	}
+	if taskPayload.EventType == "" {
+		return nil, fmt.Errorf("event_type is required")
+	}
+
+	webhook, err := ws.queries.GetWebhookByID(ctx, taskPayload.WebhookID)
+	if err != nil {
+		return nil, fmt.Errorf("get webhook: %w", err)
+	}
+	if !webhook.IsActive {
+		return json.RawMessage(`{"status":"skipped","reason":"webhook_inactive"}`), nil
+	}
+
+	var data interface{}
+	if len(taskPayload.Data) > 0 {
+		if err := json.Unmarshal(taskPayload.Data, &data); err != nil {
+			return nil, fmt.Errorf("unmarshal webhook task data: %w", err)
+		}
+	}
+
+	if err := ws.DeliverEvent(ctx, webhook, taskPayload.EventType, data); err != nil {
+		return nil, err
+	}
+
+	return json.RawMessage(`{"status":"delivered"}`), nil
 }

--- a/internal/service/webhook_test.go
+++ b/internal/service/webhook_test.go
@@ -1,10 +1,13 @@
 package service
 
 import (
+	"context"
+	"encoding/json"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateWebhookURL_InvalidScheme(t *testing.T) {
@@ -64,4 +67,30 @@ func TestSignPayload(t *testing.T) {
 	assert.Equal(t, sig1, sig2)
 	assert.NotEqual(t, sig1, sig3)
 	assert.Contains(t, sig1, "sha256=")
+}
+
+func TestMarshalWebhookDeliveryTaskPayload(t *testing.T) {
+	payload, err := marshalWebhookDeliveryTaskPayload("wh_123", "bot.created", map[string]interface{}{"id": "bot_1"})
+	require.NoError(t, err)
+
+	var decoded WebhookDeliveryTaskPayload
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	assert.Equal(t, "wh_123", decoded.WebhookID)
+	assert.Equal(t, "bot.created", decoded.EventType)
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal(decoded.Data, &data))
+	assert.Equal(t, "bot_1", data["id"])
+}
+
+func TestHandleWebhookDeliveryTask_InvalidPayload(t *testing.T) {
+	ws := &WebhookService{}
+
+	_, err := ws.HandleWebhookDeliveryTask(context.Background(), json.RawMessage(`{"event_type":"bot.created"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "webhook_id is required")
+
+	_, err = ws.HandleWebhookDeliveryTask(context.Background(), json.RawMessage(`{"webhook_id":"wh_123"}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "event_type is required")
 }


### PR DESCRIPTION
## Summary
- move webhook dispatch from inline HTTP delivery to queued  tasks
- add worker handler to process webhook delivery tasks and execute existing retrying delivery flow
- keep dispatch fast by only enqueuing tasks per active webhook
- add unit tests for webhook delivery task payload marshalling and task payload validation

## Validation
- /usr/local/go/bin/go test ./...

Closes #155