### PR TITLE
Add request ID propagation safeguard for error responses

### DIFF
--- a/internal/middleware/requestid.go
+++ b/internal/middleware/requestid.go
@@ -18,11 +18,44 @@ func RequestID(headerName string) func(http.Handler) http.Handler {
 			if id == "" {
 				id = uuid.New().String()
 			}
+
 			ctx := context.WithValue(r.Context(), RequestIDKey, id)
-			w.Header().Set(headerName, id)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			rw := &requestIDResponseWriter{
+				ResponseWriter: w,
+				headerName:     headerName,
+				requestID:      id,
+			}
+			rw.Header().Set(headerName, id)
+
+			next.ServeHTTP(rw, r.WithContext(ctx))
 		})
 	}
+}
+
+// requestIDResponseWriter guarantees request ID header propagation even if
+// downstream handlers replace/clear headers before writing an error response.
+type requestIDResponseWriter struct {
+	http.ResponseWriter
+	headerName string
+	requestID  string
+	wrote      bool
+}
+
+func (w *requestIDResponseWriter) WriteHeader(statusCode int) {
+	if !w.wrote {
+		if w.Header().Get(w.headerName) == "" {
+			w.Header().Set(w.headerName, w.requestID)
+		}
+		w.wrote = true
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *requestIDResponseWriter) Write(b []byte) (int, error) {
+	if !w.wrote {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
 }
 
 func GetRequestID(ctx context.Context) string {

--- a/internal/middleware/requestid_test.go
+++ b/internal/middleware/requestid_test.go
@@ -36,3 +36,18 @@ func TestRequestID_PropagatesExisting(t *testing.T) {
 
 	assert.Equal(t, "test-id-123", rr.Header().Get("X-Request-ID"))
 }
+
+func TestRequestID_PreservesHeaderWhenDownstreamClearsItOnError(t *testing.T) {
+	handler := RequestID("X-Request-ID")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Del("X-Request-ID")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", "req-err-999")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "req-err-999", rr.Header().Get("X-Request-ID"))
+}


### PR DESCRIPTION
## Summary
- wrap the response writer in RequestID middleware to guarantee the request ID header is re-applied before headers are written
- preserve X-Request-ID even when downstream handlers clear/replace headers before returning an error
- add middleware test coverage for error-path header propagation

## Verification
- /usr/local/go/bin/go test ./...

Closes #171