### PR TITLE
Add admin-only pprof debugging endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,27 @@ Prometheus metrics exposed at `/metrics` (path configurable via `JM_API_METRICS_
 - `http_request_errors_total` — 4xx/5xx requests
 - `db_connection_attempts_total` — startup DB connection attempts by `result` (`success`/`failure`)
 
+### Debug Profiling (pprof)
+
+Go runtime profiles are exposed at `/debug/pprof/*` and are **admin-only** (Bearer access token required with `is_admin = true`).
+
+Common endpoints:
+
+- `/debug/pprof/` — index
+- `/debug/pprof/profile?seconds=30` — CPU profile
+- `/debug/pprof/heap` — heap profile
+- `/debug/pprof/goroutine` — goroutine dump/profile
+- `/debug/pprof/mutex` — mutex contention profile
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer <admin_access_token>" \
+  "http://localhost:8000/debug/pprof/profile?seconds=10" > cpu.pprof
+
+go tool pprof -http=:0 cpu.pprof
+```
+
 ### Static Admin Dashboard
 
 A static file dashboard is served at `/admin/`. Files are embedded in the binary from the `static/` directory.

--- a/internal/server/pprof_test.go
+++ b/internal/server/pprof_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jack/jm-api-go/internal/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testJWTKey = "test-signing-key"
+
+func TestRegisterPprofRoutes_RequiresAuthentication(t *testing.T) {
+	r := chi.NewRouter()
+	registerPprofRoutes(r, middleware.Auth([]string{testJWTKey}))
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	res := httptest.NewRecorder()
+
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestRegisterPprofRoutes_RequiresAdmin(t *testing.T) {
+	r := chi.NewRouter()
+	registerPprofRoutes(r, middleware.Auth([]string{testJWTKey}))
+
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	req.Header.Set("Authorization", "Bearer "+newAccessToken(t, false))
+	res := httptest.NewRecorder()
+
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusForbidden, res.Code)
+}
+
+func TestRegisterPprofRoutes_ExposesProfilesForAdmin(t *testing.T) {
+	r := chi.NewRouter()
+	registerPprofRoutes(r, middleware.Auth([]string{testJWTKey}))
+
+	tests := []string{
+		"/debug/pprof/",
+		"/debug/pprof/heap",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/mutex",
+		"/debug/pprof/profile?seconds=1",
+	}
+
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer "+newAccessToken(t, true))
+			res := httptest.NewRecorder()
+
+			r.ServeHTTP(res, req)
+
+			assert.Equal(t, http.StatusOK, res.Code)
+		})
+	}
+}
+
+func newAccessToken(t *testing.T, isAdmin bool) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":      "user_123",
+		"email":    "admin@example.com",
+		"is_admin": isAdmin,
+		"type":     "access",
+	})
+	tokenString, err := token.SignedString([]byte(testJWTKey))
+	require.NoError(t, err)
+	return tokenString
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
+	"runtime"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -80,6 +82,7 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 	s.webhookSvc = service.NewWebhookService(s.queries, cbConfig)
 
+	s.setupProfiling()
 	s.setupRoutes()
 
 	// Start session cleanup with cancellable context
@@ -146,6 +149,29 @@ func (s *Server) Queries() *sqlc.Queries {
 	return s.queries
 }
 
+func (s *Server) setupProfiling() {
+	runtime.SetMutexProfileFraction(1)
+	runtime.SetBlockProfileRate(1)
+}
+
+func registerPprofRoutes(r chi.Router, authMW func(http.Handler) http.Handler) {
+	r.Route("/debug/pprof", func(r chi.Router) {
+		r.Use(authMW)
+		r.Use(middleware.RequireAdmin)
+
+		r.Get("/", pprof.Index)
+		r.Get("/cmdline", pprof.Cmdline)
+		r.Get("/profile", pprof.Profile)
+		r.Get("/symbol", pprof.Symbol)
+		r.Post("/symbol", pprof.Symbol)
+		r.Get("/trace", pprof.Trace)
+		r.Get("/heap", pprof.Handler("heap").ServeHTTP)
+		r.Get("/goroutine", pprof.Handler("goroutine").ServeHTTP)
+		r.Get("/mutex", pprof.Handler("mutex").ServeHTTP)
+		r.Get("/block", pprof.Handler("block").ServeHTTP)
+	})
+}
+
 func (s *Server) setupRoutes() {
 	r := s.router
 	cfg := s.cfg
@@ -194,6 +220,8 @@ func (s *Server) setupRoutes() {
 	// Auth middleware
 	authMW := middleware.Auth(cfg.JWTSigningKeys)
 	requestValidator := middleware.NewRequestValidator()
+
+	registerPprofRoutes(r, authMW)
 
 	r.Route(cfg.APIV1Prefix, func(r chi.Router) {
 		r.Use(rateLimiter.Middleware)


### PR DESCRIPTION
## Summary
- mount Go pprof endpoints at `/debug/pprof/*`
- protect profiling routes with existing JWT auth + `RequireAdmin`
- enable mutex and block profiling collection at server startup
- add server tests validating auth requirements and admin access for pprof routes
- document pprof usage in README

## Validation
- `/usr/local/go/bin/go test ./...`

Closes #180