### PR TITLE
Add Redis connection failure alerting and required health checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,4 @@ JM_API_SESSION_CLEANUP_INTERVAL_SECONDS=300
 
 # Redis (optional for local dev)
 # JM_API_REDIS_URL=redis://localhost:6379
+JM_API_REDIS_REQUIRED=false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ type Config struct {
 	RedisConnectTimeout      int
 	RedisRetryOnTimeout      bool
 	RedisHealthCheckInterval int
+	RedisRequired            bool
 
 	// Server
 	ServerPort int
@@ -205,6 +206,7 @@ func Load() (*Config, error) {
 		RedisConnectTimeout:      envInt("JM_API_REDIS_SOCKET_CONNECT_TIMEOUT", 5),
 		RedisRetryOnTimeout:      envBool("JM_API_REDIS_RETRY_ON_TIMEOUT", true),
 		RedisHealthCheckInterval: envInt("JM_API_REDIS_HEALTH_CHECK_INTERVAL", 30),
+		RedisRequired:            envBool("JM_API_REDIS_REQUIRED", false),
 
 		ServerPort: envInt("JM_API_SERVER_PORT", envInt("PORT", 8000)),
 		ServerHost: envOrDefault("JM_API_SERVER_HOST", "0.0.0.0"),
@@ -282,6 +284,10 @@ func (c *Config) validate() error {
 	}
 	if c.QueryTimeout <= 0 {
 		return fmt.Errorf("JM_API_DB_QUERY_TIMEOUT must be > 0")
+	}
+
+	if c.RedisRequired && c.RedisURL == "" {
+		return fmt.Errorf("JM_API_REDIS_URL is required when JM_API_REDIS_REQUIRED=true")
 	}
 
 	if c.RequestTimeoutDefault <= 0 || c.RequestTimeoutBotQuery <= 0 || c.RequestTimeoutWebhook <= 0 || c.RequestTimeoutAuth <= 0 || c.RequestTimeoutHealth <= 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,7 @@ func TestLoad_Defaults(t *testing.T) {
 	assert.Equal(t, 60*time.Second, cfg.RequestTimeoutWebhook)
 	assert.Equal(t, 5*time.Second, cfg.RequestTimeoutAuth)
 	assert.Equal(t, 2*time.Second, cfg.RequestTimeoutHealth)
+	assert.False(t, cfg.RedisRequired)
 	assert.Equal(t, 10, cfg.WorkerMaxConcurrency)
 	assert.Equal(t, 10, cfg.WorkerMaxPerPoll)
 	assert.Equal(t, 5*time.Second, cfg.WorkerPollInterval)
@@ -122,6 +123,15 @@ func TestLoad_InvalidSampleRate(t *testing.T) {
 	_, err := Load()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "LOG_SAMPLE_RATE")
+}
+
+func TestLoad_RedisRequired_RequiresRedisURL(t *testing.T) {
+	setEnv(t, "JM_API_DATABASE_URL", "postgres://localhost/test")
+	setEnv(t, "JM_API_REDIS_REQUIRED", "true")
+
+	_, err := Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JM_API_REDIS_URL is required")
 }
 
 func TestLoad_JWTSigningKeys(t *testing.T) {

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -10,11 +10,15 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+type RedisChecker func(ctx context.Context) error
+
 type HealthHandler struct {
 	db                    *pgxpool.Pool
 	healthBreak           atomic.Bool
 	migrationCheckEnabled bool
 	expectedMigration     int
+	redisCheck            RedisChecker
+	redisRequired         bool
 }
 
 type HealthOption func(*HealthHandler)
@@ -23,6 +27,13 @@ func WithMigrationCheck(expectedVersion int) HealthOption {
 	return func(h *HealthHandler) {
 		h.migrationCheckEnabled = true
 		h.expectedMigration = expectedVersion
+	}
+}
+
+func WithRedisCheck(check RedisChecker, required bool) HealthOption {
+	return func(h *HealthHandler) {
+		h.redisCheck = check
+		h.redisRequired = required
 	}
 }
 
@@ -76,6 +87,21 @@ func (h *HealthHandler) Health(w http.ResponseWriter, r *http.Request) {
 			overallStatus = "fail"
 		} else {
 			checks["migration"] = map[string]string{"status": "ok"}
+		}
+	}
+
+	// Redis check
+	if h.redisCheck == nil {
+		checks["redis"] = map[string]string{"status": "not_configured"}
+	} else {
+		if err := h.redisCheck(r.Context()); err != nil {
+			checks["redis"] = map[string]string{"status": "fail", "error": err.Error()}
+			if h.redisRequired {
+				status = http.StatusServiceUnavailable
+				overallStatus = "fail"
+			}
+		} else {
+			checks["redis"] = map[string]string{"status": "ok"}
 		}
 	}
 

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealth_RedisOptionalFailure_DoesNotFailOverall(t *testing.T) {
+	h := NewHealthHandler(nil, WithRedisCheck(func(_ context.Context) error {
+		return errors.New("dial tcp: connection refused")
+	}, false))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	res := httptest.NewRecorder()
+	h.Health(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	assert.Equal(t, "ok", body["status"])
+
+	checks := body["checks"].(map[string]any)
+	redis := checks["redis"].(map[string]any)
+	assert.Equal(t, "fail", redis["status"])
+	assert.Contains(t, redis["error"], "connection refused")
+}
+
+func TestHealth_RedisRequiredFailure_FailsOverall(t *testing.T) {
+	h := NewHealthHandler(nil, WithRedisCheck(func(_ context.Context) error {
+		return errors.New("redis unavailable")
+	}, true))
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	res := httptest.NewRecorder()
+	h.Health(res, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, res.Code)
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	assert.Equal(t, "fail", body["status"])
+
+	checks := body["checks"].(map[string]any)
+	redis := checks["redis"].(map[string]any)
+	assert.Equal(t, "fail", redis["status"])
+}
+
+func TestHealth_RedisNotConfigured_IncludesStatus(t *testing.T) {
+	h := NewHealthHandler(nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	res := httptest.NewRecorder()
+	h.Health(res, req)
+
+	require.Equal(t, http.StatusOK, res.Code)
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	checks := body["checks"].(map[string]any)
+	redis := checks["redis"].(map[string]any)
+	assert.Equal(t, "not_configured", redis["status"])
+}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -43,6 +43,14 @@ var (
 		},
 		[]string{"method", "endpoint"},
 	)
+
+	redisConnectionFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "redis_connection_failures_total",
+			Help: "Total number of Redis connection failures",
+		},
+		[]string{"stage"},
+	)
 )
 
 func RecordRequestTimeout(method, endpoint string) {
@@ -95,4 +103,8 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 		rw.written = true
 	}
 	return rw.ResponseWriter.Write(b)
+}
+
+func RecordRedisConnectionFailure(stage string) {
+	redisConnectionFailures.WithLabelValues(stage).Inc()
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -31,6 +32,8 @@ type Server struct {
 	router        chi.Router
 	db            *pgxpool.Pool
 	redis         *redis.Client
+	redisLastErr  error
+	redisFailures uint64
 	shutdownGuard *middleware.ShutdownGuard
 	queries       *sqlc.Queries
 	authService   *service.AuthService
@@ -114,11 +117,45 @@ func (s *Server) setupRedis(cfg *config.Config) {
 		ReadTimeout:  time.Duration(cfg.RedisSocketTimeout) * time.Second,
 	})
 	if err := s.redis.Ping(context.Background()).Err(); err != nil {
-		slog.Warn("redis connection failed, falling back to in-memory", "error", err)
+		s.redisLastErr = err
+		s.redisFailures++
+		observability.RecordRedisConnectionFailure("startup")
+		slog.Error("redis.connection.failed",
+			"timestamp", time.Now().UTC().Format(time.RFC3339Nano),
+			"error", err.Error(),
+			"retry_count", s.redisFailures,
+			"required", cfg.RedisRequired,
+		)
 		s.redis = nil
 	} else {
+		s.redisLastErr = nil
 		slog.Info("redis connected")
 	}
+}
+
+func (s *Server) redisHealthCheck(ctx context.Context) error {
+	if s.redis == nil {
+		if s.redisLastErr != nil {
+			return s.redisLastErr
+		}
+		return errors.New("redis not configured")
+	}
+
+	if err := s.redis.Ping(ctx).Err(); err != nil {
+		s.redisLastErr = err
+		s.redisFailures++
+		observability.RecordRedisConnectionFailure("healthcheck")
+		slog.Error("redis.connection.failed",
+			"timestamp", time.Now().UTC().Format(time.RFC3339Nano),
+			"error", err.Error(),
+			"retry_count", s.redisFailures,
+			"required", s.cfg.RedisRequired,
+		)
+		return err
+	}
+
+	s.redisLastErr = nil
+	return nil
 }
 
 func (s *Server) Router() chi.Router {
@@ -208,6 +245,9 @@ func (s *Server) setupRoutes() {
 	var healthOpts []handler.HealthOption
 	if cfg.DBMigrationCheckEnabled {
 		healthOpts = append(healthOpts, handler.WithMigrationCheck(cfg.DBExpectedMigration))
+	}
+	if cfg.RedisURL != "" || cfg.RedisRequired {
+		healthOpts = append(healthOpts, handler.WithRedisCheck(s.redisHealthCheck, cfg.RedisRequired))
 	}
 	healthH := handler.NewHealthHandler(s.db, healthOpts...)
 	authH := handler.NewAuthHandler(s.authService)


### PR DESCRIPTION
## Summary
- emit structured redis.connection.failed events with timestamp, error details, and retry count
- add JM_API_REDIS_REQUIRED configuration to control whether Redis is optional or required
- extend health checks to always include Redis status and return 503 when Redis is required and unavailable
- add Prometheus counter redis_connection_failures_total for startup and health-check connection failures
- add unit tests for new Redis health-check behavior and config validation

## Verification
- /usr/local/go/bin/go test ./...

Closes #182