### PR TITLE
Add webhook signature verification endpoint and Stripe-style signature format

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ All webhook endpoints require authentication. Webhooks are user-scoped — users
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
+| POST | `/api/v1/webhooks/verify` | Public | Verify webhook signature (rate-limited 10 req/min per IP) |
 | POST | `/api/v1/webhooks` | Bearer | Create a webhook |
 | GET | `/api/v1/webhooks` | Bearer | List webhooks for current user |
 | PATCH | `/api/v1/webhooks/{id}` | Bearer | Update a webhook |
@@ -218,9 +219,62 @@ Supported event types: `bot.created`, `bot.updated`, `bot.deleted`, `bot.ran`
 Webhook target URLs must be publicly reachable HTTPS or HTTP endpoints. `localhost`, `.local` domains, and private IP ranges are rejected.
 
 **Delivery mechanism:** Up to 5 attempts with exponential backoff. Each delivery POSTs JSON with headers:
-- `X-Webhook-Signature: sha256=<hmac-sha256 of body>`
+- `X-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex(timestamp + "." + raw_body)>`
 - `X-Webhook-Event: <event-type>`
 - `X-Webhook-Delivery: <event-id>`
+
+#### Signature verification test endpoint
+
+`POST /api/v1/webhooks/verify`
+
+Request body:
+```json
+{
+  "payload": "{\"id\":\"evt_123\",\"type\":\"bot.created\"}",
+  "signature": "t=1700000000,v1=649ba89390fcec3cc9ef4bdbbf4762e4cf514ce62610d493afaca4193ca61344",
+  "secret": "whsec_test"
+}
+```
+
+Response:
+- `200 {"valid":true}` when signature is valid.
+- `400 {"valid":false,"error":"..."}` when invalid.
+
+Algorithm (Stripe-style):
+1. Parse `signature` as `t=<unix>,v1=<hex>`.
+2. Build signed payload string: `"<t>.<raw payload string>"`.
+3. Compute `HMAC_SHA256(secret, signed_payload)` and compare to `v1` using constant-time compare.
+4. Reject timestamps outside a 5-minute tolerance window.
+
+Test vector implementations:
+
+```python
+import hmac, hashlib
+
+def sign(secret: str, payload: str, timestamp: int) -> str:
+    signed = f"{timestamp}.{payload}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), signed, hashlib.sha256).hexdigest()
+    return f"t={timestamp},v1={digest}"
+```
+
+```javascript
+import crypto from "node:crypto";
+
+function sign(secret, payload, timestamp) {
+  const signed = `${timestamp}.${payload}`;
+  const digest = crypto.createHmac("sha256", secret).update(signed, "utf8").digest("hex");
+  return `t=${timestamp},v1=${digest}`;
+}
+```
+
+```go
+func sign(secret, payload string, timestamp int64) string {
+    msg := fmt.Sprintf("%d.%s", timestamp, payload)
+    mac := hmac.New(sha256.New, []byte(secret))
+    mac.Write([]byte(msg))
+    return fmt.Sprintf("t=%d,v1=%s", timestamp, hex.EncodeToString(mac.Sum(nil)))
+}
+```
 
 ### Tasks
 

--- a/internal/handler/webhooks.go
+++ b/internal/handler/webhooks.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jack/jm-api-go/internal/db/sqlc"
@@ -35,13 +36,14 @@ type updateWebhookRequest struct {
 }
 
 type verifyWebhookSignatureRequest struct {
-	Payload   json.RawMessage `json:"payload"`
-	Signature string          `json:"signature"`
-	Secret    string          `json:"secret"`
+	Payload   string `json:"payload"`
+	Signature string `json:"signature"`
+	Secret    string `json:"secret"`
 }
 
 type verifyWebhookSignatureResponse struct {
-	Valid bool `json:"valid"`
+	Valid bool   `json:"valid"`
+	Error string `json:"error,omitempty"`
 }
 
 func (h *WebhookHandler) Verify(w http.ResponseWriter, r *http.Request) {
@@ -51,22 +53,26 @@ func (h *WebhookHandler) Verify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(req.Payload) == 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "payload is required"})
+	if req.Payload == "" {
+		writeJSON(w, http.StatusBadRequest, verifyWebhookSignatureResponse{Valid: false, Error: "payload is required"})
 		return
 	}
 	if req.Signature == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "signature is required"})
+		writeJSON(w, http.StatusBadRequest, verifyWebhookSignatureResponse{Valid: false, Error: "signature is required"})
 		return
 	}
 	if req.Secret == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "secret is required"})
+		writeJSON(w, http.StatusBadRequest, verifyWebhookSignatureResponse{Valid: false, Error: "secret is required"})
 		return
 	}
 
-	writeJSON(w, http.StatusOK, verifyWebhookSignatureResponse{
-		Valid: service.VerifyWebhookSignature(req.Secret, req.Payload, req.Signature),
-	})
+	valid, errMsg := service.VerifyWebhookSignatureDetailed(req.Secret, []byte(req.Payload), req.Signature, time.Now().UTC(), 5*time.Minute)
+	if !valid {
+		writeJSON(w, http.StatusBadRequest, verifyWebhookSignatureResponse{Valid: false, Error: errMsg})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, verifyWebhookSignatureResponse{Valid: true})
 }
 
 func (h *WebhookHandler) Create(w http.ResponseWriter, r *http.Request) {

--- a/internal/handler/webhooks_test.go
+++ b/internal/handler/webhooks_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jack/jm-api-go/internal/service"
@@ -18,9 +19,9 @@ func TestWebhookHandler_Verify(t *testing.T) {
 	router := chi.NewRouter()
 	router.Post("/webhooks/verify", h.Verify)
 
-	payload := json.RawMessage(`{"id":"evt_123","type":"bot.created"}`)
+	payload := `{"id":"evt_123","type":"bot.created"}`
 	secret := "supersecret"
-	validSig := service.SignWebhookPayload(secret, payload)
+	validSig := service.SignWebhookPayloadAt(secret, []byte(payload), time.Now().UTC().Unix())
 
 	t.Run("valid signature", func(t *testing.T) {
 		reqBody := map[string]any{
@@ -44,7 +45,7 @@ func TestWebhookHandler_Verify(t *testing.T) {
 	t.Run("invalid signature", func(t *testing.T) {
 		reqBody := map[string]any{
 			"payload":   payload,
-			"signature": "sha256=invalid",
+			"signature": "t=1700000000,v1=invalid",
 			"secret":    secret,
 		}
 		body, _ := json.Marshal(reqBody)
@@ -54,10 +55,11 @@ func TestWebhookHandler_Verify(t *testing.T) {
 
 		router.ServeHTTP(res, req)
 
-		require.Equal(t, http.StatusOK, res.Code)
-		var resp map[string]bool
+		require.Equal(t, http.StatusBadRequest, res.Code)
+		var resp map[string]any
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
-		assert.False(t, resp["valid"])
+		assert.Equal(t, false, resp["valid"])
+		assert.NotEmpty(t, resp["error"])
 	})
 }
 
@@ -70,9 +72,9 @@ func TestWebhookHandler_Verify_BadRequest(t *testing.T) {
 		name string
 		body string
 	}{
-		{name: "missing payload", body: `{"signature":"sha256=abc","secret":"secret"}`},
-		{name: "missing signature", body: `{"payload":{"id":"evt"},"secret":"secret"}`},
-		{name: "missing secret", body: `{"payload":{"id":"evt"},"signature":"sha256=abc"}`},
+		{name: "missing payload", body: `{"signature":"t=1700000000,v1=abc","secret":"secret"}`},
+		{name: "missing signature", body: `{"payload":"{\"id\":\"evt\"}","secret":"secret"}`},
+		{name: "missing secret", body: `{"payload":"{\"id\":\"evt\"}","signature":"t=1700000000,v1=abc"}`},
 	}
 
 	for _, tt := range tests {
@@ -83,6 +85,10 @@ func TestWebhookHandler_Verify_BadRequest(t *testing.T) {
 
 			router.ServeHTTP(res, req)
 			require.Equal(t, http.StatusBadRequest, res.Code)
+			var resp map[string]any
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&resp))
+			assert.Equal(t, false, resp["valid"])
+			assert.NotEmpty(t, resp["error"])
 		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,7 @@ func (s *Server) setupRoutes() {
 	}, middleware.WithTrustedProxies(cfg.TrustProxyHeaders, cfg.TrustedProxyCIDRs))
 	rateLimiter.SetOverride("/login", middleware.RateLimitConfig{PerMinute: 5, Window: 15 * time.Minute})
 	rateLimiter.SetOverride("/signup", middleware.RateLimitConfig{PerMinute: 5, Window: 15 * time.Minute})
+	rateLimiter.SetOverride("/webhooks/verify", middleware.RateLimitConfig{PerMinute: 10})
 
 	// Handlers
 	var healthOpts []handler.HealthOption

--- a/internal/service/webhook.go
+++ b/internal/service/webhook.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -142,19 +143,85 @@ func isPrivateIP(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
-func signPayload(secret string, payload []byte) string {
+const webhookSignatureTolerance = 5 * time.Minute
+
+func signPayload(secret string, payload []byte, timestamp int64) string {
+	signedPayload := strconv.FormatInt(timestamp, 10) + "." + string(payload)
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write(payload)
-	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	mac.Write([]byte(signedPayload))
+	return "t=" + strconv.FormatInt(timestamp, 10) + ",v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func SignWebhookPayloadAt(secret string, payload []byte, timestamp int64) string {
+	return signPayload(secret, payload, timestamp)
 }
 
 func SignWebhookPayload(secret string, payload []byte) string {
-	return signPayload(secret, payload)
+	return signPayload(secret, payload, time.Now().Unix())
+}
+
+func VerifyWebhookSignatureDetailed(secret string, payload []byte, providedSignature string, now time.Time, tolerance time.Duration) (bool, string) {
+	parts := strings.Split(strings.TrimSpace(providedSignature), ",")
+	if len(parts) < 2 {
+		return false, "signature must be in format t=<unix>,v1=<hex>"
+	}
+
+	var timestampRaw string
+	var sigCandidates []string
+	for _, part := range parts {
+		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "t":
+			timestampRaw = kv[1]
+		case "v1":
+			sigCandidates = append(sigCandidates, kv[1])
+		}
+	}
+
+	if timestampRaw == "" {
+		return false, "signature timestamp (t) is required"
+	}
+	if len(sigCandidates) == 0 {
+		return false, "signature hash (v1) is required"
+	}
+
+	timestamp, err := strconv.ParseInt(timestampRaw, 10, 64)
+	if err != nil {
+		return false, "invalid signature timestamp"
+	}
+
+	if tolerance > 0 {
+		delta := now.Unix() - timestamp
+		if delta < 0 {
+			delta = -delta
+		}
+		if time.Duration(delta)*time.Second > tolerance {
+			return false, "signature timestamp outside allowed tolerance"
+		}
+	}
+
+	expected := signPayload(secret, payload, timestamp)
+	expectedParts := strings.SplitN(expected, ",", 2)
+	expectedV1 := ""
+	if len(expectedParts) == 2 {
+		expectedV1 = strings.TrimPrefix(expectedParts[1], "v1=")
+	}
+
+	for _, candidate := range sigCandidates {
+		if hmac.Equal([]byte(expectedV1), []byte(candidate)) {
+			return true, ""
+		}
+	}
+
+	return false, "signature mismatch"
 }
 
 func VerifyWebhookSignature(secret string, payload []byte, providedSignature string) bool {
-	expected := signPayload(secret, payload)
-	return hmac.Equal([]byte(expected), []byte(strings.TrimSpace(providedSignature)))
+	valid, _ := VerifyWebhookSignatureDetailed(secret, payload, providedSignature, time.Now().UTC(), webhookSignatureTolerance)
+	return valid
 }
 
 func retryBackoffWithJitter(attempt int, random float64) time.Duration {
@@ -181,7 +248,7 @@ func (ws *WebhookService) DeliverEvent(ctx context.Context, webhook sqlc.Webhook
 		return fmt.Errorf("marshaling event: %w", err)
 	}
 
-	signature := signPayload(webhook.Secret, payload)
+	signature := SignWebhookPayload(webhook.Secret, payload)
 
 	maxAttempts := 5
 	var lastErr error

--- a/internal/service/webhook_test.go
+++ b/internal/service/webhook_test.go
@@ -62,24 +62,48 @@ func TestIsPrivateIP(t *testing.T) {
 }
 
 func TestSignPayload(t *testing.T) {
-	sig1 := signPayload("secret", []byte(`{"test": true}`))
-	sig2 := signPayload("secret", []byte(`{"test": true}`))
-	sig3 := signPayload("other-secret", []byte(`{"test": true}`))
+	payload := []byte(`{"test": true}`)
+	sig1 := signPayload("secret", payload, 1700000000)
+	sig2 := signPayload("secret", payload, 1700000000)
+	sig3 := signPayload("other-secret", payload, 1700000000)
+	sig4 := signPayload("secret", payload, 1700000001)
 
 	assert.Equal(t, sig1, sig2)
 	assert.NotEqual(t, sig1, sig3)
-	assert.Contains(t, sig1, "sha256=")
+	assert.NotEqual(t, sig1, sig4)
+	assert.Contains(t, sig1, "t=1700000000,v1=")
 }
 
 func TestVerifyWebhookSignature(t *testing.T) {
 	payload := []byte(`{"id":"evt_1","type":"bot.created"}`)
 	secret := "supersecret"
-	signature := SignWebhookPayload(secret, payload)
+	now := time.Unix(1700000100, 0).UTC()
+	signature := SignWebhookPayloadAt(secret, payload, 1700000000)
 
-	assert.True(t, VerifyWebhookSignature(secret, payload, signature))
-	assert.False(t, VerifyWebhookSignature("wrong-secret", payload, signature))
-	assert.False(t, VerifyWebhookSignature(secret, []byte(`{"id":"evt_2"}`), signature))
-	assert.False(t, VerifyWebhookSignature(secret, payload, "sha256=bad"))
+	valid, _ := VerifyWebhookSignatureDetailed(secret, payload, signature, now, 5*time.Minute)
+	assert.True(t, valid)
+
+	valid, errMsg := VerifyWebhookSignatureDetailed("wrong-secret", payload, signature, now, 5*time.Minute)
+	assert.False(t, valid)
+	assert.Equal(t, "signature mismatch", errMsg)
+
+	valid, errMsg = VerifyWebhookSignatureDetailed(secret, []byte(`{"id":"evt_2"}`), signature, now, 5*time.Minute)
+	assert.False(t, valid)
+	assert.Equal(t, "signature mismatch", errMsg)
+
+	valid, errMsg = VerifyWebhookSignatureDetailed(secret, payload, "sha256=bad", now, 5*time.Minute)
+	assert.False(t, valid)
+	assert.Contains(t, errMsg, "format")
+}
+
+func TestVerifyWebhookSignatureDetailed_ExpiredTimestamp(t *testing.T) {
+	payload := []byte(`{"id":"evt_1"}`)
+	secret := "supersecret"
+	signature := SignWebhookPayloadAt(secret, payload, 1700000000)
+
+	valid, errMsg := VerifyWebhookSignatureDetailed(secret, payload, signature, time.Unix(1700000400, 0).UTC(), 5*time.Minute)
+	assert.False(t, valid)
+	assert.Equal(t, "signature timestamp outside allowed tolerance", errMsg)
 }
 
 func TestMarshalWebhookDeliveryTaskPayload(t *testing.T) {


### PR DESCRIPTION
## Summary
- updated webhook signing to Stripe-style format: t=<unix>,v1=<hmac_sha256(timestamp.payload)>
- implemented stricter POST /api/v1/webhooks/verify contract (payload, signature, secret as strings)
- endpoint now returns 200 {valid:true} for valid signatures and 400 {valid:false,error:<msg>} for invalid signatures
- added explicit rate-limit override for verify endpoint: 10 requests/min per IP
- documented signature algorithm, expected format, and multi-language test vectors in README
- added/updated handler and service tests covering success/failure and timestamp tolerance

## Validation
- /usr/local/go/bin/go test ./...

Closes #183