### PR TITLE
Fix CD health check flakiness after Heroku deploy

### DIFF
--- a/.github/scripts/verify_deployment_health.sh
+++ b/.github/scripts/verify_deployment_health.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[health-check] %s\n' "$*"
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    log "Required environment variable missing: ${name}"
+    exit 1
+  fi
+}
+
+wait_for_heroku_dyno() {
+  local app_name="$1"
+
+  if ! command -v heroku >/dev/null 2>&1; then
+    log "Heroku CLI is not installed; skipping dyno wait"
+    return
+  fi
+
+  log "Checking Heroku dyno status for app '${app_name}'"
+  if ! heroku ps --app "${app_name}"; then
+    log "Unable to fetch dyno status via 'heroku ps'; continuing to health checks"
+    return
+  fi
+
+  log "Waiting for Heroku dynos to report up via 'heroku ps:wait'"
+  if ! heroku ps:wait --app "${app_name}"; then
+    log "Heroku dynos did not stabilize before timeout; continuing to explicit health checks"
+  fi
+}
+
+run_health_checks() {
+  local health_url="$1"
+  local max_attempts="$2"
+  local retry_delay_seconds="$3"
+  local curl_timeout_seconds="$4"
+
+  local response_file
+  local curl_error_file
+  response_file="$(mktemp)"
+  curl_error_file="$(mktemp)"
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    : >"${response_file}"
+    : >"${curl_error_file}"
+
+    local http_status
+    if http_status="$(curl -sS -L --max-time "${curl_timeout_seconds}" -o "${response_file}" -w "%{http_code}" "${health_url}" 2>"${curl_error_file}")"; then
+      if [[ "${http_status}" == "200" ]]; then
+        log "Health check passed on attempt ${attempt}/${max_attempts} (HTTP ${http_status})"
+        rm -f "${response_file}" "${curl_error_file}"
+        return 0
+      fi
+    else
+      http_status="000"
+    fi
+
+    log "Attempt ${attempt}/${max_attempts} failed"
+    log "HTTP status: ${http_status}"
+
+    if [[ -s "${curl_error_file}" ]]; then
+      log "curl error:"
+      sed 's/^/[health-check]   /' "${curl_error_file}"
+    fi
+
+    if [[ -s "${response_file}" ]]; then
+      log "Response body (first 500 chars):"
+      head -c 500 "${response_file}" | sed 's/^/[health-check]   /'
+      printf '\n'
+    else
+      log "Response body is empty"
+    fi
+
+    if (( attempt < max_attempts )); then
+      log "Retrying in ${retry_delay_seconds}s..."
+      sleep "${retry_delay_seconds}"
+    fi
+  done
+
+  log "Health check failed after ${max_attempts} attempts"
+  rm -f "${response_file}" "${curl_error_file}"
+  return 1
+}
+
+main() {
+  require_env "HEALTH_URL"
+
+  local initial_delay_seconds="${HEALTH_INITIAL_DELAY_SECONDS:-30}"
+  local max_attempts="${HEALTH_MAX_ATTEMPTS:-10}"
+  local retry_delay_seconds="${HEALTH_RETRY_DELAY_SECONDS:-15}"
+  local curl_timeout_seconds="${HEALTH_CURL_TIMEOUT_SECONDS:-10}"
+
+  log "Waiting ${initial_delay_seconds}s before checking health endpoint"
+  sleep "${initial_delay_seconds}"
+
+  if [[ -n "${HEROKU_APP_NAME:-}" ]]; then
+    wait_for_heroku_dyno "${HEROKU_APP_NAME}"
+  else
+    log "HEROKU_APP_NAME not set; skipping dyno wait"
+  fi
+
+  log "Checking health endpoint: ${HEALTH_URL}"
+  run_health_checks "${HEALTH_URL}" "${max_attempts}" "${retry_delay_seconds}" "${curl_timeout_seconds}"
+}
+
+main "$@"

--- a/.github/scripts/verify_deployment_health_test.sh
+++ b/.github/scripts/verify_deployment_health_test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_SCRIPT="${SCRIPT_DIR}/verify_deployment_health.sh"
+
+pass_count=0
+fail_count=0
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local message="$3"
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    pass_count=$((pass_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL: ${message}"
+    echo "  expected to find: ${needle}"
+    echo "  in output: ${haystack}"
+  fi
+}
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local message="$3"
+  if [[ "${actual}" == "${expected}" ]]; then
+    pass_count=$((pass_count + 1))
+  else
+    fail_count=$((fail_count + 1))
+    echo "FAIL: ${message}"
+    echo "  expected: ${expected}"
+    echo "  actual:   ${actual}"
+  fi
+}
+
+run_case() {
+  local case_name="$1"
+  local sequence="$2"
+  local include_heroku="$3"
+
+  local tempdir
+  tempdir="$(mktemp -d)"
+  local mockbin="${tempdir}/bin"
+  mkdir -p "${mockbin}"
+
+  cat >"${mockbin}/curl" <<'MOCKCURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file=""
+write_format=""
+url=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output_file="$2"
+      shift 2
+      ;;
+    -w)
+      write_format="$2"
+      shift 2
+      ;;
+    --max-time)
+      shift 2
+      ;;
+    -s|-S|-L)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+counter_file="${MOCK_COUNTER_FILE}"
+state_file="${MOCK_SEQUENCE_FILE}"
+count=0
+if [[ -f "${counter_file}" ]]; then
+  count="$(cat "${counter_file}")"
+fi
+count=$((count + 1))
+echo "${count}" >"${counter_file}"
+
+IFS=',' read -ra statuses <<<"${MOCK_STATUS_SEQUENCE}"
+idx=$((count - 1))
+status="${statuses[$idx]:-${statuses[-1]}}"
+
+echo "${url} attempt ${count}" >"${output_file}"
+printf "%s" "${status}"
+
+if [[ "${status}" == "000" ]]; then
+  echo "simulated connection failure" >&2
+  exit 1
+fi
+MOCKCURL
+
+  chmod +x "${mockbin}/curl"
+
+  if [[ "${include_heroku}" == "yes" ]]; then
+    cat >"${mockbin}/heroku" <<'MOCKHEROKU'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "$*" >>"${MOCK_HEROKU_LOG}"
+exit 0
+MOCKHEROKU
+    chmod +x "${mockbin}/heroku"
+  fi
+
+  local output
+  local exit_code=0
+  set +e
+  output="$(
+    PATH="${mockbin}:${PATH}" \
+    MOCK_COUNTER_FILE="${tempdir}/counter" \
+    MOCK_SEQUENCE_FILE="${tempdir}/sequence" \
+    MOCK_STATUS_SEQUENCE="${sequence}" \
+    MOCK_HEROKU_LOG="${tempdir}/heroku.log" \
+    HEALTH_URL="https://example.com/api/v1/health" \
+    HEROKU_APP_NAME="test-app" \
+    HEALTH_INITIAL_DELAY_SECONDS=0 \
+    HEALTH_RETRY_DELAY_SECONDS=0 \
+    HEALTH_MAX_ATTEMPTS=5 \
+    "${TARGET_SCRIPT}" 2>&1
+  )"
+  exit_code=$?
+  set -e
+
+  echo "${output}" >"${tempdir}/output.log"
+  echo "${exit_code}" >"${tempdir}/exit_code"
+  echo "${tempdir}"
+}
+
+# Case 1: retries and succeeds
+tmp1="$(run_case success_after_retries "503,503,200" yes)"
+out1="$(cat "${tmp1}/output.log")"
+code1="$(cat "${tmp1}/exit_code")"
+assert_eq "${code1}" "0" "script exits 0 when health eventually succeeds"
+assert_contains "${out1}" "Attempt 1/5 failed" "logs first failed attempt"
+assert_contains "${out1}" "Health check passed on attempt 3/5" "logs successful attempt number"
+heroku_calls1="$(cat "${tmp1}/heroku.log")"
+assert_contains "${heroku_calls1}" "ps --app test-app" "calls heroku ps"
+assert_contains "${heroku_calls1}" "ps:wait --app test-app" "calls heroku ps:wait"
+
+# Case 2: exhaust attempts and fail
+tmp2="$(run_case fail_after_retries "503,503,503,503,503" no)"
+out2="$(cat "${tmp2}/output.log")"
+code2="$(cat "${tmp2}/exit_code")"
+assert_eq "${code2}" "1" "script exits non-zero when health never succeeds"
+assert_contains "${out2}" "Health check failed after 5 attempts" "logs final failure summary"
+assert_contains "${out2}" "Response body (first 500 chars):" "logs response body details on failure"
+
+if (( fail_count > 0 )); then
+  echo "${pass_count} assertions passed, ${fail_count} assertions failed"
+  exit 1
+fi
+
+echo "All ${pass_count} assertions passed"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,27 +41,21 @@ jobs:
           set -x
           GIT_TRACE=1 GIT_CURL_VERBOSE=1 git push https://git.heroku.com/${HEROKU_APP_NAME}.git HEAD:main
 
-      - name: Verify deployment health
+      - name: Install Heroku CLI
         run: |
-          echo "Waiting for deployment to stabilize..."
-          sleep 30
-          
-          HEALTH_URL="${{ vars.PRODUCTION_BASE_URL }}/api/v1/health"
+          curl https://cli-assets.heroku.com/install.sh | sh
 
-          echo "Checking health endpoint: ${HEALTH_URL}"
-
-          for i in {1..5}; do
-            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${HEALTH_URL}" || echo "000")
-            if [ "${HTTP_STATUS}" = "200" ]; then
-              echo "Health check passed (HTTP ${HTTP_STATUS})"
-              exit 0
-            fi
-            echo "Attempt ${i}/5: Health check returned HTTP ${HTTP_STATUS}, retrying in 10s..."
-            sleep 10
-          done
-
-          echo "Health check failed after 5 attempts"
-          exit 1
+      - name: Verify deployment health
+        env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEALTH_URL: ${{ vars.PRODUCTION_BASE_URL }}/api/v1/health
+          HEALTH_INITIAL_DELAY_SECONDS: "30"
+          HEALTH_MAX_ATTEMPTS: "10"
+          HEALTH_RETRY_DELAY_SECONDS: "15"
+          HEALTH_CURL_TIMEOUT_SECONDS: "10"
+        run: |
+          ./.github/scripts/verify_deployment_health.sh
 
       - name: Notify deployment status
         if: always()


### PR DESCRIPTION
## Summary
- replace inline deploy health check loop with a dedicated script that provides detailed diagnostics
- wait for Heroku dynos with  and  before probing the API
- increase retries/delay to better tolerate cold starts and release startup latency
- log HTTP status, curl errors, and response body snippets on failed checks
- add shell-based tests covering retry success, retry exhaustion, and Heroku wait behavior

## Verification
- All 8 assertions passed

Closes #186