### PR TITLE
Fix Heroku dyno startup by hardening server port fallback

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -45,7 +45,14 @@ func run() error {
 	defer stop()
 
 	go func() {
-		slog.Info("starting server", "addr", httpServer.Addr, "env", cfg.Environment)
+		slog.Info(
+			"starting server",
+			"addr", httpServer.Addr,
+			"host", cfg.ServerHost,
+			"port", cfg.ServerPort,
+			"heroku_port_env", os.Getenv("PORT"),
+			"env", cfg.Environment,
+		)
 		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("server error", "error", err)
 			os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,7 +208,7 @@ func Load() (*Config, error) {
 		RedisHealthCheckInterval: envInt("JM_API_REDIS_HEALTH_CHECK_INTERVAL", 30),
 		RedisRequired:            envBool("JM_API_REDIS_REQUIRED", false),
 
-		ServerPort: envInt("JM_API_SERVER_PORT", envInt("PORT", 8000)),
+		ServerPort: envIntFromKeys([]string{"JM_API_SERVER_PORT", "PORT"}, 8000),
 		ServerHost: envOrDefault("JM_API_SERVER_HOST", "0.0.0.0"),
 
 		RequestTimeoutDefault:  envDuration("JM_API_REQUEST_TIMEOUT_DEFAULT", 30*time.Second),
@@ -396,7 +396,7 @@ func envIntFromKeys(keys []string, defaultVal int) int {
 		if v := os.Getenv(key); v != "" {
 			i, err := strconv.Atoi(v)
 			if err != nil {
-				return defaultVal
+				continue
 			}
 			return i
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -161,6 +161,35 @@ func TestLoad_InvalidCIDR(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid trusted proxy CIDR")
 }
 
+func TestLoad_ServerPort_FromPORTFallback(t *testing.T) {
+	setEnv(t, "JM_API_DATABASE_URL", "postgres://localhost/test")
+	setEnv(t, "PORT", "54321")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, 54321, cfg.ServerPort)
+}
+
+func TestLoad_ServerPort_JMAPIOverridesPORT(t *testing.T) {
+	setEnv(t, "JM_API_DATABASE_URL", "postgres://localhost/test")
+	setEnv(t, "PORT", "54321")
+	setEnv(t, "JM_API_SERVER_PORT", "9000")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, 9000, cfg.ServerPort)
+}
+
+func TestLoad_ServerPort_InvalidJMAPIFallsBackToPORT(t *testing.T) {
+	setEnv(t, "JM_API_DATABASE_URL", "postgres://localhost/test")
+	setEnv(t, "PORT", "54321")
+	setEnv(t, "JM_API_SERVER_PORT", "not-a-number")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Equal(t, 54321, cfg.ServerPort)
+}
+
 func TestLoad_CustomValues(t *testing.T) {
 	setEnv(t, "JM_API_DATABASE_URL", "postgres://localhost/test")
 	setEnv(t, "JM_API_APP_NAME", "custom-api")


### PR DESCRIPTION
Summary: replace nested server-port env parsing with ordered lookup (JM_API_SERVER_PORT then PORT then 8000), make multi-key int parsing fall through on invalid higher-priority values, add startup diagnostics logging for bind host/port and raw Heroku PORT env, and add config tests for PORT fallback/precedence. Testing: added unit tests in internal/config/config_test.go; attempted go test ./... but go is not installed in this environment.

Closes #188