### PR TITLE
Implement Redis failure alerting with rate limiter fallback

### DIFF
--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"strconv"
@@ -12,6 +13,8 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+
+	"github.com/jack/jm-api-go/internal/observability"
 )
 
 type RateLimitConfig struct {
@@ -179,8 +182,14 @@ func (rl *RateLimiter) checkRedis(ctx context.Context, key string, limit int, wi
 	pipe.Expire(ctx, redisKey, window)
 	_, err := pipe.Exec(ctx)
 	if err != nil {
-		// On error, allow the request
-		return true, limit - 1, resetAt
+		observability.RecordRedisConnectionFailure("ratelimiter")
+		slog.Error("redis.connection.failed",
+			"timestamp", now.UTC().Format(time.RFC3339Nano),
+			"error", err.Error(),
+			"stage", "ratelimiter",
+			"fallback", "in_memory",
+		)
+		return rl.checkMemory(key, limit, window, now, resetAt)
 	}
 
 	count := int(incrCmd.Val())

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -150,7 +150,7 @@ func TestRateLimiter_WindowRefill_AllowsAfterReset(t *testing.T) {
 	assert.Equal(t, http.StatusOK, refillRR.Code)
 }
 
-func TestRateLimiter_RedisUnavailable_FailsOpen(t *testing.T) {
+func TestRateLimiter_RedisUnavailable_FallsBackToMemory(t *testing.T) {
 	redisClient := redis.NewClient(&redis.Options{
 		Addr:         "127.0.0.1:0",
 		DialTimeout:  5 * time.Millisecond,
@@ -160,16 +160,20 @@ func TestRateLimiter_RedisUnavailable_FailsOpen(t *testing.T) {
 	})
 	t.Cleanup(func() { _ = redisClient.Close() })
 
-	rl := NewRateLimiter(redisClient, RateLimitConfig{PerMinute: 1})
+	rl := NewRateLimiter(redisClient, RateLimitConfig{PerMinute: 1, Window: 5 * time.Second})
 	handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	for i := 0; i < 3; i++ {
-		req := httptest.NewRequest("GET", "/", nil)
-		req.RemoteAddr = "8.8.8.8:1234"
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusOK, rr.Code)
-	}
+	allowedReq := httptest.NewRequest("GET", "/", nil)
+	allowedReq.RemoteAddr = "8.8.8.8:1234"
+	allowedRes := httptest.NewRecorder()
+	handler.ServeHTTP(allowedRes, allowedReq)
+	assert.Equal(t, http.StatusOK, allowedRes.Code)
+
+	blockedReq := httptest.NewRequest("GET", "/", nil)
+	blockedReq.RemoteAddr = "8.8.8.8:1234"
+	blockedRes := httptest.NewRecorder()
+	handler.ServeHTTP(blockedRes, blockedReq)
+	assert.Equal(t, http.StatusTooManyRequests, blockedRes.Code)
 }


### PR DESCRIPTION
## Summary
- add structured redis.connection.failed logging in the rate limiter when Redis operations fail
- emit Redis failure metric events for rate limiter failures (stage=ratelimiter) to support alerting
- switch behavior from fail-open to in-memory fallback limiting when Redis is unavailable
- add test coverage to verify Redis outage now falls back to in-memory enforcement

## Validation
- /usr/local/go/bin/go test ./...

Closes #170