### PR TITLE
test: strengthen pprof admin-auth coverage

### DIFF
--- a/internal/server/pprof_test.go
+++ b/internal/server/pprof_test.go
@@ -30,13 +30,24 @@ func TestRegisterPprofRoutes_RequiresAdmin(t *testing.T) {
 	r := chi.NewRouter()
 	registerPprofRoutes(r, middleware.Auth([]string{testJWTKey}))
 
-	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
-	req.Header.Set("Authorization", "Bearer "+newAccessToken(t, false))
-	res := httptest.NewRecorder()
+	paths := []string{
+		"/debug/pprof/",
+		"/debug/pprof/heap",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/profile?seconds=1",
+	}
 
-	r.ServeHTTP(res, req)
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.Header.Set("Authorization", "Bearer "+newAccessToken(t, false))
+			res := httptest.NewRecorder()
 
-	assert.Equal(t, http.StatusForbidden, res.Code)
+			r.ServeHTTP(res, req)
+
+			assert.Equal(t, http.StatusForbidden, res.Code)
+		})
+	}
 }
 
 func TestRegisterPprofRoutes_ExposesProfilesForAdmin(t *testing.T) {


### PR DESCRIPTION
## Summary
- verified issue #169 requirements are present in codebase: /debug/pprof/* routes are mounted and protected by auth + admin middleware
- added stronger tests to ensure non-admin users are denied access to key profiling endpoints (/ , /heap, /goroutine, /profile)
- confirmed profiling endpoints for CPU/heap/goroutine remain accessible to admin users

## Validation
- PATH=/usr/local/go/bin:$PATH go test ./internal/server ./...

Closes #169