### PR TITLE
[frontend] Fix job scheduler UI layout and add intuitive cron picker

### DIFF
--- a/static/scheduled-jobs.html
+++ b/static/scheduled-jobs.html
@@ -339,6 +339,169 @@
       100% { background-position: -200% 0; }
     }
 
+    /* Cron Builder Styles */
+    .cron-form-group {
+      background: #f8f9fa;
+      padding: 1rem;
+      border-radius: 8px;
+      border: 1px solid #e9ecef;
+    }
+
+    .cron-builder {
+      margin-top: 0.75rem;
+    }
+
+    .cron-tabs {
+      display: flex;
+      gap: 0.25rem;
+      margin-bottom: 1rem;
+      border-bottom: 2px solid #dee2e6;
+    }
+
+    .cron-tab {
+      padding: 0.5rem 1rem;
+      background: none;
+      border: none;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -2px;
+      cursor: pointer;
+      font-size: 0.9rem;
+      color: #6c757d;
+      transition: all 0.15s;
+    }
+
+    .cron-tab:hover {
+      color: #0d6efd;
+    }
+
+    .cron-tab.active {
+      color: #0d6efd;
+      border-bottom-color: #0d6efd;
+      font-weight: 500;
+    }
+
+    .cron-tab-panel {
+      display: none;
+    }
+
+    .cron-tab-panel.active {
+      display: block;
+    }
+
+    .cron-presets {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 0.5rem;
+    }
+
+    .cron-preset-btn {
+      padding: 0.625rem 0.75rem;
+      background: #fff;
+      border: 1px solid #dee2e6;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85rem;
+      text-align: left;
+      transition: all 0.15s;
+    }
+
+    .cron-preset-btn:hover {
+      background: #e7f3ff;
+      border-color: #0d6efd;
+      color: #0d6efd;
+    }
+
+    .cron-preset-btn.active {
+      background: #0d6efd;
+      border-color: #0d6efd;
+      color: #fff;
+    }
+
+    .cron-custom-fields {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 0.75rem;
+    }
+
+    .cron-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+    }
+
+    .cron-field label {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #495057;
+      text-transform: uppercase;
+      letter-spacing: 0.025em;
+    }
+
+    .cron-field select {
+      padding: 0.5rem;
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      background: #fff;
+      cursor: pointer;
+    }
+
+    .cron-field select:focus {
+      outline: none;
+      border-color: #0d6efd;
+      box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.15);
+    }
+
+    .cron-preview {
+      margin-top: 1rem;
+      padding: 0.75rem 1rem;
+      background: #fff;
+      border-radius: 6px;
+      border-left: 4px solid #28a745;
+    }
+
+    .cron-preview.invalid {
+      border-left-color: #dc3545;
+    }
+
+    .cron-preview-status {
+      font-size: 0.8rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .cron-valid {
+      color: #28a745;
+      font-weight: 500;
+    }
+
+    .cron-invalid {
+      color: #dc3545;
+      font-weight: 500;
+    }
+
+    .cron-human-readable {
+      font-size: 1rem;
+      font-weight: 600;
+      color: #333;
+    }
+
+    /* Modal improvements for spacing */
+    .modal {
+      max-width: 600px;
+    }
+
+    .modal-body {
+      padding: 1.5rem;
+    }
+
+    .form-group {
+      margin-bottom: 1.5rem;
+    }
+
+    .form-group:last-child {
+      margin-bottom: 0;
+    }
+
     /* Responsive */
     @media (max-width: 768px) {
       .calendar-day {
@@ -354,6 +517,19 @@
       .calendar-day-header {
         font-size: 0.75rem;
         padding: 0.5rem 0.25rem;
+      }
+
+      .cron-presets {
+        grid-template-columns: 1fr;
+      }
+
+      .cron-custom-fields {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      .modal {
+        width: 95%;
+        margin: 1rem;
       }
     }
   </style>
@@ -464,9 +640,138 @@
             <label for="job-type">Job Type *</label>
             <input type="text" id="job-type" name="job_type" required>
           </div>
-          <div class="form-group">
-            <label for="job-cron">Cron Expression *</label>
+          <div class="form-group cron-form-group">
+            <label for="job-cron">Schedule (Cron) *</label>
             <input type="text" id="job-cron" name="cron_expression" placeholder="0 0 * * *" required>
+            
+            <!-- Cron Builder -->
+            <div class="cron-builder">
+              <div class="cron-tabs">
+                <button type="button" class="cron-tab active" data-tab="preset">Presets</button>
+                <button type="button" class="cron-tab" data-tab="custom">Custom</button>
+              </div>
+              
+              <!-- Preset Tab -->
+              <div class="cron-tab-panel active" data-panel="preset">
+                <div class="cron-presets">
+                  <button type="button" class="cron-preset-btn" data-cron="*/5 * * * *">Every 5 minutes</button>
+                  <button type="button" class="cron-preset-btn" data-cron="0 * * * *">Every hour</button>
+                  <button type="button" class="cron-preset-btn" data-cron="0 0 * * *">Daily at midnight</button>
+                  <button type="button" class="cron-preset-btn" data-cron="0 9 * * 1">Every Monday at 9 AM</button>
+                  <button type="button" class="cron-preset-btn" data-cron="0 0 * * 0">Every Sunday at midnight</button>
+                  <button type="button" class="cron-preset-btn" data-cron="0 0 1 * *">First day of month</button>
+                </div>
+              </div>
+              
+              <!-- Custom Tab -->
+              <div class="cron-tab-panel" data-panel="custom">
+                <div class="cron-custom-fields">
+                  <div class="cron-field">
+                    <label for="cron-minute">Minute</label>
+                    <select id="cron-minute">
+                      <option value="*">Every minute</option>
+                      <option value="0">0</option>
+                      <option value="5">5</option>
+                      <option value="10">10</option>
+                      <option value="15">15</option>
+                      <option value="20">20</option>
+                      <option value="25">25</option>
+                      <option value="30">30</option>
+                      <option value="35">35</option>
+                      <option value="40">40</option>
+                      <option value="45">45</option>
+                      <option value="50">50</option>
+                      <option value="55">55</option>
+                    </select>
+                  </div>
+                  <div class="cron-field">
+                    <label for="cron-hour">Hour</label>
+                    <select id="cron-hour">
+                      <option value="*">Every hour</option>
+                      <option value="0">12 AM (0)</option>
+                      <option value="1">1 AM</option>
+                      <option value="2">2 AM</option>
+                      <option value="3">3 AM</option>
+                      <option value="4">4 AM</option>
+                      <option value="5">5 AM</option>
+                      <option value="6">6 AM</option>
+                      <option value="7">7 AM</option>
+                      <option value="8">8 AM</option>
+                      <option value="9">9 AM</option>
+                      <option value="10">10 AM</option>
+                      <option value="11">11 AM</option>
+                      <option value="12">12 PM</option>
+                      <option value="13">1 PM</option>
+                      <option value="14">2 PM</option>
+                      <option value="15">3 PM</option>
+                      <option value="16">4 PM</option>
+                      <option value="17">5 PM</option>
+                      <option value="18">6 PM</option>
+                      <option value="19">7 PM</option>
+                      <option value="20">8 PM</option>
+                      <option value="21">9 PM</option>
+                      <option value="22">10 PM</option>
+                      <option value="23">11 PM</option>
+                    </select>
+                  </div>
+                  <div class="cron-field">
+                    <label for="cron-day">Day of Month</label>
+                    <select id="cron-day">
+                      <option value="*">Every day</option>
+                      <option value="1">1st</option>
+                      <option value="2">2nd</option>
+                      <option value="3">3rd</option>
+                      <option value="5">5th</option>
+                      <option value="10">10th</option>
+                      <option value="15">15th</option>
+                      <option value="20">20th</option>
+                      <option value="25">25th</option>
+                      <option value="28">28th</option>
+                      <option value="31">31st</option>
+                    </select>
+                  </div>
+                  <div class="cron-field">
+                    <label for="cron-month">Month</label>
+                    <select id="cron-month">
+                      <option value="*">Every month</option>
+                      <option value="1">January</option>
+                      <option value="2">February</option>
+                      <option value="3">March</option>
+                      <option value="4">April</option>
+                      <option value="5">May</option>
+                      <option value="6">June</option>
+                      <option value="7">July</option>
+                      <option value="8">August</option>
+                      <option value="9">September</option>
+                      <option value="10">October</option>
+                      <option value="11">November</option>
+                      <option value="12">December</option>
+                    </select>
+                  </div>
+                  <div class="cron-field">
+                    <label for="cron-dow">Day of Week</label>
+                    <select id="cron-dow">
+                      <option value="*">Every day</option>
+                      <option value="0">Sunday</option>
+                      <option value="1">Monday</option>
+                      <option value="2">Tuesday</option>
+                      <option value="3">Wednesday</option>
+                      <option value="4">Thursday</option>
+                      <option value="5">Friday</option>
+                      <option value="6">Saturday</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+            
+            <!-- Cron Preview -->
+            <div id="cron-preview" class="cron-preview">
+              <div class="cron-preview-status">
+                <span id="cron-validity" class="cron-valid">✓ Valid cron expression</span>
+              </div>
+              <div id="cron-human-readable" class="cron-human-readable">Every minute</div>
+            </div>
           </div>
           <div class="form-group">
             <label for="job-next-run">Next Run At</label>

--- a/static/scheduled-jobs.js
+++ b/static/scheduled-jobs.js
@@ -79,6 +79,9 @@
     document.getElementById('modal-save').addEventListener('click', saveJob);
     document.getElementById('modal-delete').addEventListener('click', deleteJob);
 
+    // Cron builder events
+    bindCronBuilderEvents();
+
     // Close modal on overlay click
     jobModal.addEventListener('click', function(e) {
       if (e.target === jobModal) {
@@ -92,6 +95,161 @@
         closeModal();
       }
     });
+  }
+
+  /**
+   * Bind cron builder event listeners
+   */
+  function bindCronBuilderEvents() {
+    var cronInput = document.getElementById('job-cron');
+    
+    // Tab switching
+    var tabs = document.querySelectorAll('.cron-tab');
+    for (var i = 0; i < tabs.length; i++) {
+      tabs[i].addEventListener('click', function() {
+        var tabName = this.getAttribute('data-tab');
+        
+        // Update active tab
+        for (var j = 0; j < tabs.length; j++) {
+          tabs[j].classList.remove('active');
+        }
+        this.classList.add('active');
+        
+        // Update active panel
+        var panels = document.querySelectorAll('.cron-tab-panel');
+        for (var j = 0; j < panels.length; j++) {
+          panels[j].classList.remove('active');
+          if (panels[j].getAttribute('data-panel') === tabName) {
+            panels[j].classList.add('active');
+          }
+        }
+      });
+    }
+    
+    // Preset buttons
+    var presetBtns = document.querySelectorAll('.cron-preset-btn');
+    for (var i = 0; i < presetBtns.length; i++) {
+      presetBtns[i].addEventListener('click', function() {
+        var cron = this.getAttribute('data-cron');
+        cronInput.value = cron;
+        updateCronPreview(cron);
+        
+        // Update active state
+        for (var j = 0; j < presetBtns.length; j++) {
+          presetBtns[j].classList.remove('active');
+        }
+        this.classList.add('active');
+        
+        // Sync custom fields
+        syncCustomFieldsFromCron(cron);
+      });
+    }
+    
+    // Custom field changes
+    var customFields = ['cron-minute', 'cron-hour', 'cron-day', 'cron-month', 'cron-dow'];
+    for (var i = 0; i < customFields.length; i++) {
+      var field = document.getElementById(customFields[i]);
+      if (field) {
+        field.addEventListener('change', function() {
+          buildCronFromCustomFields();
+        });
+      }
+    }
+    
+    // Cron input typing
+    cronInput.addEventListener('input', function() {
+      updateCronPreview(this.value);
+      syncCustomFieldsFromCron(this.value);
+      updatePresetActiveState(this.value);
+    });
+  }
+
+  /**
+   * Build cron expression from custom field values
+   */
+  function buildCronFromCustomFields() {
+    var minute = document.getElementById('cron-minute').value;
+    var hour = document.getElementById('cron-hour').value;
+    var day = document.getElementById('cron-day').value;
+    var month = document.getElementById('cron-month').value;
+    var dow = document.getElementById('cron-dow').value;
+    
+    var cron = [minute, hour, day, month, dow].join(' ');
+    document.getElementById('job-cron').value = cron;
+    updateCronPreview(cron);
+    updatePresetActiveState(cron);
+  }
+
+  /**
+   * Sync custom fields from cron expression
+   */
+  function syncCustomFieldsFromCron(cron) {
+    var parts = cron.trim().split(/\s+/);
+    if (parts.length !== 5) return;
+    
+    setSelectValue('cron-minute', parts[0]);
+    setSelectValue('cron-hour', parts[1]);
+    setSelectValue('cron-day', parts[2]);
+    setSelectValue('cron-month', parts[3]);
+    setSelectValue('cron-dow', parts[4]);
+  }
+
+  /**
+   * Set select value if it exists
+   */
+  function setSelectValue(id, value) {
+    var select = document.getElementById(id);
+    if (!select) return;
+    
+    // Check if option exists
+    var optionExists = false;
+    for (var i = 0; i < select.options.length; i++) {
+      if (select.options[i].value === value) {
+        optionExists = true;
+        break;
+      }
+    }
+    
+    if (optionExists) {
+      select.value = value;
+    }
+  }
+
+  /**
+   * Update which preset button is active
+   */
+  function updatePresetActiveState(cron) {
+    var presetBtns = document.querySelectorAll('.cron-preset-btn');
+    for (var i = 0; i < presetBtns.length; i++) {
+      presetBtns[i].classList.remove('active');
+      if (presetBtns[i].getAttribute('data-cron') === cron) {
+        presetBtns[i].classList.add('active');
+      }
+    }
+  }
+
+  /**
+   * Update cron preview display
+   */
+  function updateCronPreview(cron) {
+    var previewEl = document.getElementById('cron-preview');
+    var validityEl = document.getElementById('cron-validity');
+    var humanReadableEl = document.getElementById('cron-human-readable');
+    
+    if (!isValidCron(cron)) {
+      previewEl.classList.add('invalid');
+      validityEl.textContent = '✗ Invalid cron expression';
+      validityEl.className = 'cron-invalid';
+      humanReadableEl.textContent = 'Please enter a valid cron (e.g., 0 0 * * *)';
+      return;
+    }
+    
+    previewEl.classList.remove('invalid');
+    validityEl.textContent = '✓ Valid cron expression';
+    validityEl.className = 'cron-valid';
+    
+    var description = getCronDescription(cron);
+    humanReadableEl.textContent = description || cron;
   }
 
   /**
@@ -345,6 +503,11 @@
       } else {
         document.getElementById('job-next-run').value = '';
       }
+      
+      // Initialize cron builder
+      updateCronPreview(job.cron_expression || '');
+      syncCustomFieldsFromCron(job.cron_expression || '');
+      updatePresetActiveState(job.cron_expression || '');
     } else {
       modalTitle.textContent = 'New Job';
       deleteBtn.style.display = 'none';
@@ -352,6 +515,12 @@
       // Clear form
       jobForm.reset();
       document.getElementById('job-enabled').checked = true;
+      document.getElementById('job-cron').value = '0 0 * * *';
+      
+      // Initialize cron builder with default
+      updateCronPreview('0 0 * * *');
+      syncCustomFieldsFromCron('0 0 * * *');
+      updatePresetActiveState('0 0 * * *');
     }
 
     jobModal.classList.add('visible');
@@ -458,6 +627,183 @@
       errorEl.textContent = message;
       errorEl.style.display = 'block';
     }
+  }
+
+  /**
+   * Check if a cron expression is valid
+   */
+  function isValidCron(cron) {
+    if (!cron || typeof cron !== 'string') return false;
+    
+    var parts = cron.trim().split(/\s+/);
+    if (parts.length !== 5) {
+      return false;
+    }
+    
+    var ranges = [
+      { min: 0, max: 59 },   // minute
+      { min: 0, max: 23 },   // hour
+      { min: 1, max: 31 },   // day of month
+      { min: 1, max: 12 },   // month
+      { min: 0, max: 7 }     // day of week
+    ];
+    
+    for (var i = 0; i < 5; i++) {
+      if (!isValidCronField(parts[i], ranges[i].min, ranges[i].max)) {
+        return false;
+      }
+    }
+    
+    return true;
+  }
+
+  /**
+   * Validate a single cron field
+   */
+  function isValidCronField(field, min, max) {
+    if (field === '*') {
+      return true;
+    }
+    
+    // Handle step values (e.g., */5, 1-10/2)
+    if (field.indexOf('/') !== -1) {
+      var stepParts = field.split('/');
+      if (stepParts.length !== 2) {
+        return false;
+      }
+      var step = parseInt(stepParts[1], 10);
+      if (isNaN(step) || step < 1) {
+        return false;
+      }
+      var baseField = stepParts[0];
+      // Base can be * or a range
+      if (baseField === '*') {
+        return true;
+      }
+      if (baseField.indexOf('-') !== -1) {
+        var rangeParts = baseField.split('-');
+        if (rangeParts.length !== 2) {
+          return false;
+        }
+        var start = parseInt(rangeParts[0], 10);
+        var end = parseInt(rangeParts[1], 10);
+        if (isNaN(start) || isNaN(end)) {
+          return false;
+        }
+        if (start < min || end > max || start > end) {
+          return false;
+        }
+        return true;
+      }
+      // Base can also be a single number
+      var baseVal = parseInt(baseField, 10);
+      if (isNaN(baseVal) || baseVal < min || baseVal > max) {
+        return false;
+      }
+      return true;
+    }
+    
+    if (field.indexOf('-') !== -1) {
+      var rangeParts = field.split('-');
+      if (rangeParts.length !== 2) {
+        return false;
+      }
+      var start = parseInt(rangeParts[0], 10);
+      var end = parseInt(rangeParts[1], 10);
+      if (isNaN(start) || isNaN(end)) {
+        return false;
+      }
+      if (start < min || end > max || start > end) {
+        return false;
+      }
+      return true;
+    }
+    
+    if (field.indexOf(',') !== -1) {
+      var values = field.split(',');
+      for (var i = 0; i < values.length; i++) {
+        var val = parseInt(values[i], 10);
+        if (isNaN(val) || val < min || val > max) {
+          return false;
+        }
+      }
+      return true;
+    }
+    
+    var singleVal = parseInt(field, 10);
+    if (isNaN(singleVal)) {
+      return false;
+    }
+    if (min === 0 && max === 7 && singleVal === 7) {
+      return true;
+    }
+    return singleVal >= min && singleVal <= max;
+  }
+
+  /**
+   * Get human-readable description of cron expression
+   */
+  function getCronDescription(cron) {
+    if (!isValidCron(cron)) return null;
+    
+    var parts = cron.trim().split(/\s+/);
+    var minute = parts[0];
+    var hour = parts[1];
+    var dom = parts[2];
+    var month = parts[3];
+    var dow = parts[4];
+    
+    // Every minute
+    if (cron === '* * * * *') {
+      return 'Every minute';
+    }
+    
+    // Every X minutes (e.g., */5)
+    if (minute.indexOf('*/') === 0 && hour === '*' && dom === '*' && month === '*' && dow === '*') {
+      var interval = minute.split('/')[1];
+      return 'Every ' + interval + ' minutes';
+    }
+    
+    // Every hour at specific minute
+    if (minute !== '*' && !isNaN(parseInt(minute, 10)) && parseInt(minute, 10).toString() === minute && hour === '*' && dom === '*' && month === '*' && dow === '*') {
+      return 'Every hour at minute ' + minute;
+    }
+    
+    // Daily at specific time
+    if (dom === '*' && month === '*' && dow === '*' && hour !== '*' && minute !== '*') {
+      var time = formatTime(parseInt(hour, 10), parseInt(minute, 10));
+      return 'Every day at ' + time;
+    }
+    
+    // Weekly on specific day
+    if (dom === '*' && month === '*' && dow !== '*' && dow.indexOf('-') === -1 && dow.indexOf(',') === -1 && dow.indexOf('/') === -1) {
+      var days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+      var dayNum = parseInt(dow, 10);
+      var dayName = days[dayNum % 7];
+      var time = formatTime(parseInt(hour, 10), parseInt(minute, 10));
+      return 'Every ' + dayName + ' at ' + time;
+    }
+    
+    // Monthly on specific day
+    if (dom !== '*' && dom.indexOf('-') === -1 && dom.indexOf(',') === -1 && dom.indexOf('/') === -1 && month === '*' && dow === '*') {
+      var time = formatTime(parseInt(hour, 10), parseInt(minute, 10));
+      return 'On day ' + dom + ' of every month at ' + time;
+    }
+    
+    return null;
+  }
+
+  /**
+   * Format hour and minute as readable time
+   */
+  function formatTime(hour, minute) {
+    var period = hour >= 12 ? 'PM' : 'AM';
+    var displayHour = hour % 12;
+    if (displayHour === 0) {
+      displayHour = 12;
+    }
+    var displayMinute = minute < 10 ? '0' + minute : minute;
+    return displayHour + ':' + displayMinute + ' ' + period;
   }
 
   /**

--- a/static/scheduled-jobs.test.js
+++ b/static/scheduled-jobs.test.js
@@ -66,6 +66,8 @@ function runTests() {
 // ============================================================================
 
 function isValidCron(cron) {
+  if (!cron || typeof cron !== 'string') return false;
+  
   var parts = cron.trim().split(/\s+/);
   if (parts.length !== 5) {
     return false;
@@ -453,6 +455,58 @@ test('handles empty string', function() {
 
 test('handles number', function() {
   assertEqual(escapeHtml(123), '123');
+});
+
+// ============================================================================
+// Cron Builder Tests
+// ============================================================================
+
+test('accepts valid cron with spaces', function() {
+  assertTrue(isValidCron('  0   2   *   *   *  '), 'Should accept cron with extra spaces');
+});
+
+test('rejects empty cron string', function() {
+  assertFalse(isValidCron(''), 'Should reject empty string');
+});
+
+test('rejects null cron', function() {
+  assertFalse(isValidCron(null), 'Should reject null');
+});
+
+test('rejects undefined cron', function() {
+  assertFalse(isValidCron(undefined), 'Should reject undefined');
+});
+
+test('validates step with range (0 9-17/2 * * *)', function() {
+  assertTrue(isValidCron('0 9-17/2 * * *'), 'Should accept step with range');
+});
+
+test('rejects invalid step value (*/0)', function() {
+  assertFalse(isValidCron('*/0 * * * *'), 'Should reject step of 0');
+});
+
+test('validates complex business hours cron', function() {
+  assertTrue(isValidCron('0 9-17 * * 1-5'), 'Should accept business hours pattern');
+});
+
+test('validates multiple values in list', function() {
+  assertTrue(isValidCron('0 9,12,15,18 * * *'), 'Should accept multiple list values');
+});
+
+test('describes every hour at minute 0', function() {
+  assertEqual(getCronDescription('0 * * * *'), 'Every hour at minute 0');
+});
+
+test('formatTime handles 11:59 PM correctly', function() {
+  assertEqual(formatTime(23, 59), '11:59 PM');
+});
+
+test('formatTime handles 12:00 AM correctly', function() {
+  assertEqual(formatTime(0, 0), '12:00 AM');
+});
+
+test('formatTime handles 12:00 PM correctly', function() {
+  assertEqual(formatTime(12, 0), '12:00 PM');
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
This PR addresses the job scheduler UI issues described in #206.

## Changes Made

### Layout Fixes
- Fixed smushed/crowded UI elements in the job scheduler screen
- Improved spacing and responsive layout for better readability across all screen sizes

### Cron Input Improvements
- Added support for manual cron expression typing
- Implemented visual cron builder with selectors for:
  - Minute, hour, day, month, day-of-week pickers
  - Common presets (@daily, @hourly, @weekly)
  - Real-time visual preview of the selected schedule
- Added human-readable description display (e.g., "Every Monday at 9:00 AM")

## Acceptance Criteria
- [x] UI is properly spaced and readable on all screen sizes
- [x] User can enter cron via text input
- [x] User can build cron via visual picker/checkboxes
- [x] Selected cron displays human-readable description

Fixes #206