### PR TITLE
Fix CSRF failures for bearer-authenticated scheduled job writes

### DIFF
--- a/internal/middleware/csrf.go
+++ b/internal/middleware/csrf.go
@@ -8,10 +8,20 @@ import (
 
 // CSRF validates that the X-CSRF-Token header matches the csrf_token cookie
 // on all state-changing requests (POST, PATCH, PUT, DELETE).
+//
+// Requests authenticated with an explicit Bearer token are exempt because the
+// browser does not attach Authorization headers cross-site automatically, so
+// they are not vulnerable to classic cookie-based CSRF.
 func CSRF(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+		if strings.HasPrefix(strings.ToLower(authHeader), "bearer ") && strings.TrimSpace(authHeader[7:]) != "" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/middleware/csrf_test.go
+++ b/internal/middleware/csrf_test.go
@@ -132,3 +132,29 @@ func TestCSRF_BlocksPOSTWithMissingHeader(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
 }
+
+func TestCSRF_AllowsPOSTWithBearerTokenWithoutCSRFToken(t *testing.T) {
+	handler := CSRF(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Header.Set("Authorization", "Bearer access-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestCSRF_BlocksPOSTWithMalformedBearerPrefixAndNoCSRFToken(t *testing.T) {
+	handler := CSRF(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("should not reach handler")
+	}))
+
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Header.Set("Authorization", "Bearer")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}


### PR DESCRIPTION
## Summary
- update CSRF middleware to bypass cookie/header CSRF checks for requests authenticated with an explicit Authorization Bearer header
- keep strict CSRF cookie/header validation for cookie-authenticated mutating requests
- add middleware tests covering bearer-token bypass and malformed bearer header behavior

## Why
The scheduled jobs UI sends authenticated API writes using bearer auth. Those requests were incorrectly blocked by cookie-style CSRF checks, causing CSRF validation failed when saving jobs.

## Testing
- /usr/local/go/bin/go test ./... -count=1

Closes #210